### PR TITLE
ci: restore release-trigger on publish.yml (PyPI Trusted Publisher LIVE)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,11 +1,13 @@
 name: Publish to PyPI
 
 on:
-  # release.types=[published] removed 2026-05-14 — PyPI Trusted Publisher
-  # not yet configured on the PyPI side; auto-triggering on every release
-  # was causing red CI runs. Re-enable once `pip install memexa` is wired
-  # via PyPI trusted publishing (see ROADMAP v0.1.0 stable / v0.2 PyPI
-  # release). Until then, publish manually via workflow_dispatch.
+  # release-trigger restored 2026-05-14 after PyPI Trusted Publisher was
+  # configured (project=memexa, owner=labazhou2024, workflow=publish.yml,
+  # environment=pypi) and the first manual publish (workflow_dispatch
+  # target=pypi @ v0.1.0-rc1) succeeded. From now on, every published
+  # GitHub release auto-publishes to PyPI.
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       target:


### PR DESCRIPTION
## Why

PyPI Trusted Publisher is now configured (project=`memexa`, owner=`labazhou2024`, workflow=`publish.yml`, environment=`pypi`) and **the first manual publish succeeded**: https://pypi.org/project/memexa/ — `pip install --pre memexa` works.

Re-enabling `release.types: [published]` so every future GitHub release auto-publishes to PyPI without manual `workflow_dispatch`.

## Why this was disabled in PR #6

Before PyPI side was wired, the release-trigger was producing red CI runs (`invalid-publisher` because the GitHub OIDC token had no corresponding publisher on PyPI yet). See PR #6 commit body.

## Verification

- ✅ Run 25868030991 (workflow_dispatch target=pypi @ v0.1.0-rc1) — both jobs green
- ✅ `curl https://pypi.org/pypi/memexa/json` returns 200 with `version: 0.1.0a0`

## Known caveat (separate follow-up)

`pyproject.toml version = "0.1.0a0"` is **alpha**, not RC. `pip install memexa` (without `--pre`) currently fails. Will bump version to `0.1.0rc1` in a separate PR before pushing promo content publicly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)