### PR TITLE
chore: bump version 0.1.0a0 → 0.1.0rc1 (PyPI label sync)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "memexa"
-version = "0.1.0a0"
+version = "0.1.0rc1"
 description = "镜我 · Your personal Pensieve. Turn scattered Chinese data into ready-to-use deliverables."
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Why

The PyPI publish on 2026-05-14 went out as `0.1.0a0` due to a stale version label in `pyproject.toml`. GitHub tag and release page both label this as `v0.1.0-rc1`, so package metadata should match.

## Effect

- `pip install --pre memexa` resolves to `0.1.0rc1` (preferred over `0.1.0a0` per PEP 440)
- `0.1.0a0` stays on PyPI forever (PyPI policy, can't unpublish)
- After merge: delete `v0.1.0-rc1` tag → retag on new HEAD → re-publish GitHub release → publish.yml auto-fires → PyPI gets `0.1.0rc1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)