### PR TITLE
fix(ci): src/ → memexa/ in workflow paths (followup to #9)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,9 @@ jobs:
           python -m pip install -U pip
           pip install -e ".[dev]"
       - name: Ruff (correctness rules only — style queued for v0.2)
-        run: ruff check src tests
+        run: ruff check memexa tests
       - name: Black (check only, warn-only for v0.1.0-rc1)
-        run: black --check src tests
+        run: black --check memexa tests
         continue-on-error: true
 
   test:
@@ -60,10 +60,10 @@ jobs:
       - name: Import smoke
         run: |
           python -c "import pkgutil, importlib; \
-            [importlib.import_module(name) for _, name, _ in pkgutil.iter_modules(['src/core'], 'memexa.core.')]; \
+            [importlib.import_module(name) for _, name, _ in pkgutil.iter_modules(['memexa/core'], 'memexa.core.')]; \
             print('import smoke OK')"
       - name: Pytest (unit + integration)
-        run: pytest -m "not e2e" --cov=src --cov-report=xml --cov-report=term-missing
+        run: pytest -m "not e2e" --cov=memexa --cov-report=xml --cov-report=term-missing
       - name: Upload coverage to Codecov
         if: matrix.os == 'ubuntu-latest' && matrix.python == '3.11'
         uses: codecov/codecov-action@v4

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -26,7 +26,7 @@ jobs:
         # informational confidence; combined with the per-rule skips this
         # surfaces real issues without false-positives on internal cache
         # keys (SHA1/MD5 used as content fingerprints, not for crypto).
-        run: bandit -r src -c pyproject.toml -ll
+        run: bandit -r memexa -c pyproject.toml -ll
         continue-on-error: true  # warn-only for v0.1.0-rc1; tighten in v0.2
 
   secret-scan:


### PR DESCRIPTION
PR #9 renamed src/ → memexa/ in code but missed hardcoded `src` paths in CI workflows. Result: ruff/black/bandit/coverage all error with E902 "No such file or directory".

Fixes:
- ci.yml ruff + black + coverage paths
- security.yml bandit path

CI on this PR is the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)