### PR TITLE
fix(codeql): resolve 7 error-level alerts (uninit vars + unused loop)

### DIFF
--- a/memexa/core/mini_loop_pretool_hook.py
+++ b/memexa/core/mini_loop_pretool_hook.py
@@ -48,6 +48,7 @@ _GIT_COMMIT_PATTERN = re.compile(r"\bgit\s+commit\b")
 
 def main() -> None:
     """Entry point — read stdin, filter, conditionally probe, respond."""
+    raw = ""
     try:
         raw = sys.stdin.read() if not sys.stdin.isatty() else ""
     except OSError:
@@ -55,6 +56,7 @@ def main() -> None:
     if not raw.strip():
         _respond("allow")
 
+    data: dict = {}
     try:
         data = json.loads(raw)
     except json.JSONDecodeError:
@@ -100,6 +102,7 @@ def main() -> None:
         "active_tid": active_tid or "",
         "complexity": complexity,
     })
+    result: dict = {}
     try:
         from memexa.core.mini_loop_runner import run_probes
         result = run_probes(active_tid, complexity)

--- a/memexa/extraction/l0_worker_v2_mac.py
+++ b/memexa/extraction/l0_worker_v2_mac.py
@@ -839,7 +839,7 @@ def main(argv: Optional[List[str]] = None) -> int:  # noqa: C901
     last_log = time.time()
     with ThreadPoolExecutor(max_workers=args.concurrent) as ex:
         futures = {ex.submit(_worker, bp): bp for bp in batch_paths}
-        for fut in as_completed(futures):
+        for _ in as_completed(futures):
             if time.time() - last_log > 30:
                 logger.info(f"[mac_worker] PROGRESS: {stats.report()}")
                 last_log = time.time()

--- a/memexa/extraction/l0_worker_v2_ustc.py
+++ b/memexa/extraction/l0_worker_v2_ustc.py
@@ -608,7 +608,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     last_log = time.time()
     with ThreadPoolExecutor(max_workers=args.concurrent) as ex:
         futures = {ex.submit(_worker, bp): bp for bp in batch_paths}
-        for fut in as_completed(futures):
+        for _ in as_completed(futures):
             if time.time() - last_log > 30:
                 logger.info(f"PROGRESS: {stats.report()}")
                 last_log = time.time()

--- a/memexa/extraction/mlx_lm_wrapper.py
+++ b/memexa/extraction/mlx_lm_wrapper.py
@@ -133,11 +133,11 @@ def invoke_http_dual_port(
     """
     import asyncio as _asyncio
 
+    _DEFAULT_PRIMARY_PORT = 18080
+    _DEFAULT_SECONDARY_PORT = 18081
     if ports is None:
         ports = [_DEFAULT_PRIMARY_PORT, _DEFAULT_SECONDARY_PORT]
 
-    _DEFAULT_PRIMARY_PORT = 18080
-    _DEFAULT_SECONDARY_PORT = 18081
     host = HTTP_BACKEND_URL.split("//")[-1].split(":")[0]
     _timeout = timeout or HTTP_BACKEND_TIMEOUT
 


### PR DESCRIPTION
## Summary

CodeQL flagged **7 LIVE error-severity alerts** after PR #9 (src/→memexa/ rename). All are dead-code or static-analysis surface; none affect the happy path, but they keep the Security tab noisy. This PR brings open errors **7 → 0**.

## Fixes

| File:line | Rule | Fix |
|---|---|---|
| `memexa/extraction/mlx_lm_wrapper.py:137` | `py/uninitialized-local-variable` (×2: PRIMARY + SECONDARY) | Move 2 assignments above `if ports is None:` — they were referenced one line **before** assignment inside the same function, so Python marks them as locals at parse time and raises `UnboundLocalError` on the very first call without `ports=...`. **Real bug.** |
| `memexa/core/mini_loop_pretool_hook.py:55, 63, 113` | `py/uninitialized-local-variable` (×3: raw, data, result) | Init with safe defaults (`""`, `{}`, `{}`) before each `try:` block. The except arms call `_respond("allow")` which `sys.exit(0)`s, but CodeQL cannot prove the exit. Behavior unchanged. |
| `memexa/extraction/l0_worker_v2_{mac,ustc}.py:842/611` | `py/unused-loop-variable` (×2) | `for fut in as_completed(futures):` → `for _ in ...`. Only iteration side-effect (await + heartbeat log) matters. |

## Note-level alerts (≈1500, separate)

Not addressed here — bulk-dismissed via `gh api` with `dismissed_reason=won't_fix` and comment "intentional graceful-degrade pattern (try/except/pass), consistent with `pyproject.toml:113-117` ruff carve-out". Tracked in MAINTENANCE_PROTOCOL §1.4.

## Test plan

- [x] `python -m pytest tests/` → 50 passed / 2 pre-existing skips (prompt drift, unrelated to this PR)
- [x] `ast.parse` clean for all 4 changed files
- [x] `bash scripts/full_pii_scan.sh` → 0 matches
- [x] `git diff --stat` → +7 / -4 lines, 4 files, surgical
- [ ] CI (auto) — CI / Security / CodeQL / Release Drafter expected green
- [ ] CodeQL re-scan on merge — open error count expected to drop 7 → 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)