### PR TITLE
feat(rc3): agent-first brand + memexa demo + --json mode + 3-tier quickstart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,78 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`memexa demo` subcommand**: thirty-second onboarding that ingests
+  the bundled synthetic dataset with the stub extractor and runs five
+  sample queries (`quick` / `arc` / `timeline` / `pending` / `topic`).
+  No Docker, no LLM API key, no configuration required. Designed as
+  the first-time visitor path; advertised in README quickstart.
+- **`--json` output mode for all fourteen query subcommands**.
+  Top-level flag short-circuits text rendering and emits the raw
+  return value (list or dict) as a single JSON document on stdout.
+  This is the structured-output path for AI agents (Claude Code,
+  Cursor, Cline) invoking memexa via shell subprocess — the
+  first-class agent integration until v0.5 ships the native MCP
+  server.
+- **`docs/why.md` + `docs/why.zh.md`**: per-capability comparison
+  against OpenHuman / MemPalace / ReMe, agent-first design rationale,
+  glossary covering project-specific terms (verbatim raw + V2
+  envelope; reflow; Chinese-IM reflow; audio + voice reflow; workflow
+  spec).
+- **`docs/cost.md` + `docs/cost.zh.md`**: API call volume and cost
+  estimation for DeepSeek (V4 Flash / Pro), GPT-4o, and Claude 4.x,
+  with three-tier user profiles and recommended model combinations
+  for Chinese workloads.
+
 ### Changed
 
-- **docs(qq)**: rewrite the QQ integration page to reflect the dual-track
-  reality — NapCat path deprecated and disabled by default, db-only and
-  clipboard adapters LIVE in upstream JARVIS (`jarvis/qq_db.py`,
-  `jarvis/qq_reader.py`) and scheduled for OSS migration in v0.2. Bilingual.
-- **docs(env)**: rename `MEMEXA_USTC_CONCURRENT` → `MEMEXA_EXTRACT_CONCURRENT`
-  in `configuration.md`, `performance.md`, `troubleshooting.md` (en + zh).
-  No `memexa/` callsites — pure docs rename.
-- **roadmap**: add explicit v0.2 milestone for the QQ adapter migration
-  (5 sub-tasks).
+- **Project positioning**: clarified as **agent backbone** —
+  the primary user is an AI agent (Claude Code / Cursor / Cline)
+  invoking memexa as a subprocess on a human user's behalf. The
+  fourteen subcommands plus seven hard rules in `docs/for_agents.md`
+  are the agent contract. Direct CLI use by a human is also
+  supported but is the secondary path.
+- **README first screen**: positioning line and the "AI-agent
+  compatible by design" paragraph restored; Quickstart now has two
+  sections (humans 30-second visual, agents subprocess + `--json`);
+  documentation index updated.
+- **`docs/quickstart.md`**: Tier 0 now has two paths — humans run
+  `memexa demo`, agents call subcommands with `--json`. Tier 1 and
+  Tier 2 remain unchanged.
+- **`ROADMAP.md`**: v0.2 redefined from "Python deliverable code +
+  CLI subcommands" to **Markdown workflow specs** under
+  `docs/templates/`. Agents read the spec at runtime; users add
+  their own by copying a markdown file. v0.5 promotes the subprocess
+  path to a native MCP server. v0.7 formalises user-authored
+  workflow specs. New v0.8+ section for optional desktop GUI
+  exploration, gated on v0.5 / v0.7 success conditions.
+- **`Makefile`**: `fmt` and `lint` targets corrected to use
+  `memexa tests` instead of the deprecated `src tests` path (residue
+  from PR #9's `src/`→`memexa/` rename).
+
+### Fixed
+
+- CodeQL: seven error-level alerts resolved (uninitialised local
+  variables in `mlx_lm_wrapper.py` and `mini_loop_pretool_hook.py`,
+  unused loop variables in two `l0_worker_v2_*.py` modules). 866
+  note- and warning-level alerts dismissed as known alpha-stage
+  technical debt (intentional graceful-degrade patterns; queued for
+  full ruff sweep in v0.2). Open code-scanning alerts now zero.
+
+### Security
+
+- Dependabot vulnerability alerts and automated security fixes
+  enabled at the repository level.
+
+## [0.1.0-rc2] — 2026-05-14
+
+Install bug fix on top of rc1.
+
+### Fixed
+
+- Package layout: `src/` renamed to `memexa/` to match the installed
+  import path; PR #9 + CI followup in PR #10.
 
 ## [0.1.0-rc1] — 2026-05-14
 
@@ -48,22 +109,51 @@ before cutting v0.1.0 stable.
   (`scripts/full_pii_scan.sh`).
 - Threat-model documentation (`SECURITY.md`).
 
-### Known limitations (rc1)
+## [0.1.0] — TBD (release criteria, kept in sync with ROADMAP)
 
-- `pip install memexa` not yet available on PyPI; install from GitHub.
-- Mac/Linux fresh-clone smoke test not yet covered by CI on every push;
-  scheduled for v0.1.0 stable.
+Cut from a green release candidate when **all** of the following hold:
 
-## [0.1.0] — TBD
+- The `memexa demo` subcommand has been LIVE on PyPI for at least one
+  week and `pip install --pre memexa && memexa demo` returns rc=0 on
+  fresh Windows, macOS, and Linux installs (already verified in CI
+  by PR #12 / PR #14 matrices, but the LIVE PyPI check is the gate).
+- At least one issue, discussion, or pull request from a non-author
+  contributor has been opened against the repository.
+- No critical bug fix has shipped in the past seven days.
 
-Cut from a green rc after ≥ 1 week of feedback, when:
+The actual version-bump pull request closes this section and links to
+the rc that became `0.1.0`.
 
-- Fresh-clone smoke test passes on Win + macOS + Linux in CI.
-- All eight query subcommands return non-empty results against the
-  demo dataset.
-- Test suite passes on Python 3.10 / 3.11 / 3.12.
-- Dashboard renders on a fresh install without manual intervention.
+## [0.1.0-rc1] — 2026-05-14
 
-[Unreleased]: https://github.com/labazhou2024/memexa/compare/v0.1.0-rc1...HEAD
+First public release candidate. Single orphan commit. Open for feedback
+before cutting v0.1.0 stable.
+
+### Added
+
+- Six ingestion sources: WeChat, QQ, email, browser, Claude Code, audio.
+- Two-LLM gate-extract pipeline (gatekeeper + extractor + BGE-M3 quorum
+  + DeepSeek arbiter).
+- PostgreSQL + pgvector backend via Hindsight FastAPI.
+- 14 query subcommands plus the five-phase state inference workflow.
+- Live dashboard on `:8765`.
+- Cron orchestrator with dead-letter retry and PG-aware pending.
+- Windows / macOS / Linux deployment guides.
+- Five reproducible walkthroughs against the bundled demo dataset
+  (`examples/demo_dataset/walkthroughs/`).
+- Two end-to-end case studies (`docs/case_studies/`).
+- AI-agent protocol document (`docs/for_agents.md`) — hard rules,
+  decision table, composition patterns, common pitfalls.
+- Full Chinese mirror of every user-facing doc (`*.zh.md`).
+
+### Security
+
+- PII scrubbing pre-commit hook (`scripts/pre-commit-pii-scan.sh`).
+- Full-tree PII residual scan with self-referential SKIP list
+  (`scripts/full_pii_scan.sh`).
+- Threat-model documentation (`SECURITY.md`).
+
+[Unreleased]: https://github.com/labazhou2024/memexa/compare/v0.1.0-rc2...HEAD
+[0.1.0-rc2]: https://github.com/labazhou2024/memexa/releases/tag/v0.1.0-rc2
 [0.1.0-rc1]: https://github.com/labazhou2024/memexa/releases/tag/v0.1.0-rc1
 [0.1.0]: https://github.com/labazhou2024/memexa/releases/tag/v0.1.0

--- a/Makefile
+++ b/Makefile
@@ -32,13 +32,13 @@ install:
 	pre-commit install
 
 fmt:
-	ruff check --fix src tests
-	ruff format src tests
-	black src tests
+	ruff check --fix memexa tests
+	ruff format memexa tests
+	black memexa tests
 
 lint:
-	ruff check src tests
-	black --check src tests
+	ruff check memexa tests
+	black --check memexa tests
 
 test:
 	pytest -m "not integration and not e2e" -ra

--- a/README.md
+++ b/README.md
@@ -19,29 +19,94 @@ repository-topics:
 
 **English** · [中文](README.zh.md)
 
-> **Your personal Pensieve.**
-> Take the data scattered across your six silos, reorganize it around the task you have right now, and walk away with a usable document.
+> **Memory layer for AI agents and humans, on Chinese-native data.**
+> Self-hosted memory graph over WeChat / QQ / 飞书 / 钉钉 group chats,
+> Chinese email, and Chinese audio. Verbatim storage plus structured
+> extraction; queries return cards with per-claim citations back to
+> the original sentence.
+>
+> 🤖 **AI-agent compatible by design.** Most real usage is an AI agent
+> (Claude Code, Cursor, Cline, or one you wrote yourself) invoking
+> memexa as a subprocess to answer questions on the user's behalf.
+> The fourteen query subcommands are a small protocol; the contract
+> agents follow is in [`docs/for_agents.md`](docs/for_agents.md).
+> Native MCP integration arrives in v0.5; the current first-class
+> path is shell subprocess with `--json` output.
 
 [![CI](https://github.com/labazhou2024/memexa/actions/workflows/ci.yml/badge.svg)](https://github.com/labazhou2024/memexa/actions/workflows/ci.yml)
 [![CodeQL](https://github.com/labazhou2024/memexa/actions/workflows/codeql.yml/badge.svg)](https://github.com/labazhou2024/memexa/actions/workflows/codeql.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](pyproject.toml)
-[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![PyPI](https://img.shields.io/pypi/v/memexa?label=PyPI)](https://pypi.org/project/memexa/)
 [![PII scan](https://img.shields.io/badge/PII%20residual-0%20matches-success.svg)](scripts/full_pii_scan.sh)
 
-## What is this
+## Quickstart
 
-`memexa` ingests six categories of everyday Chinese-language data (WeChat, QQ,
-email, browser history, AI conversations, voice memos), extracts entities /
-relationships / temporal evidence with a two-LLM pipeline, stores them in a
-PostgreSQL + pgvector memory graph, and then uses **14 query subcommands** to
-pull out whatever you need right now — *who was looking for me? what's the
-whole story behind this? what's on my plate? where is project X across all
-sources?*
+Two starting points; pick whichever describes you.
 
-Inspired by the Pensieve in Harry Potter — pour the memories scattered in
-your head into a basin, rearrange them, observe them, extract what matters
-for the moment.
+### Humans — 30-second visual
+
+```bash
+pip install --pre memexa
+memexa demo
+```
+
+You will see a synthetic conversation set ingested from six sources
+with the stub extractor, followed by five example queries printed to
+your terminal — `quick`, `arc`, `timeline`, `pending`, `topic`. No
+backend, no LLM, no configuration. This is the honest first look at
+what the project does.
+
+### AI agents — subprocess CLI today, MCP in v0.5
+
+```bash
+# Agents already work today via subprocess:
+pip install --pre memexa
+memexa quick "<your question>" --json   # structured output for agent parsing
+memexa arc "<person>" --json
+# ... fourteen subcommands total, all with --json mode (v0.1.x)
+```
+
+The fourteen subcommands plus seven hard rules in
+[`docs/for_agents.md`](docs/for_agents.md) are the agent contract.
+Native MCP integration (`memexa-mcp` server + `.mcp.json` snippet)
+arrives in v0.5; until then shell subprocess is the first-class path
+and it works in any agent that has a shell tool.
+
+### What's next for both
+
+To ingest your own data, configure an LLM provider and pick one
+source. [`docs/quickstart.md`](docs/quickstart.md) walks through Tier
+1 (5 minutes, one source) and Tier 2 (30 minutes, full production
+deployment with cron + dashboard).
+
+## What you can ask
+
+| Question pattern | Subcommand | Returns |
+|---|---|---|
+| Who is Alice? | `arc "Alice"` | Relationship arc, 8 fan-out variants across sources |
+| What was the whole story behind X? | `topic "Mac purchase"` | 80–200 cards with citations |
+| What did Y professor want? | `person "Y professor"` | Profile article + recent events |
+| What is project X across all sources? | `project "X"` | Cross-source pulse, 4 source groups |
+| What is on my plate? | `pending` | Active commitments from calendar |
+| What did this period look like? | `timeline --start ... --end ...` | Chronological card list |
+| Synthesise an answer | `reflect "question"` | LLM-synthesised Markdown |
+
+Fourteen subcommands total. Decision table and composition patterns
+are in [`docs/usage_guide.md`](docs/usage_guide.md). See also
+[`docs/5_phase_query.md`](docs/5_phase_query.md) for the state-
+inference workflow used on yes/no questions.
+
+## Why memexa instead of OpenHuman / MemPalace / ReMe?
+
+In short: verbatim raw storage + LLM-extracted V2 envelope + per-claim
+`evidence_quotes` citation + cross-alias canonical id, all on
+Chinese-IM-native data sources the adjacent projects do not target.
+
+The full per-capability comparison and the five user scenarios memexa
+serves live in [`docs/why.md`](docs/why.md).
+
+## Architecture, one screen
 
 ```
    WeChat ─┐                                              ┌─► "Who is X?"           (arc + quick)
@@ -55,245 +120,51 @@ for the moment.
    (local, fully self-hosted)                             (cross-source composable)
 ```
 
-> **v0.1 scope**: complete ingestion + extraction + query + dashboard +
-> **5 walkthroughs + 2 case studies**. The "auto-generate deliverables"
-> layer ships in [ROADMAP.md](ROADMAP.md) v0.2 as **three universal
-> templates** — `weekly` / `brief` / `retro` — covering all five user
-> scenarios (knowledge worker / researcher / creator / small-business /
-> self-quantified). v0.7 opens up user-authored templates so the
-> deliverable layer becomes an ecosystem. For v0.1, compose the 14
-> query commands manually for the same effect.
->
-> 🚀 **First time here?** Jump to [Example walkthroughs ↓](#-example-walkthroughs--5-reproducible-scenarios)
-> to see 5 real scenarios end-to-end.
+Full architecture in [`docs/architecture.md`](docs/architecture.md).
 
-> 🤖 **AI-agent compatible by design.** Most real users invoke memexa
-> through an AI agent — Claude Code, Cursor, Cline, or one they wrote
-> themselves — rather than typing subcommands by hand. The 14 query
-> subcommands are a small protocol; the protocol document for agents is
-> [docs/for_agents.md](docs/for_agents.md) (hard rules, decision table,
-> composition patterns, common pitfalls). If you're shipping an
-> agent that needs a Chinese-data memory layer, start there.
+## Documentation
 
-## Five user scenarios (broad Chinese-market design intent)
-
-memexa targets the broader Chinese-speaking market — not a single
-demographic. All five scenarios share the same backbone (ingestion +
-two-LLM extract + graph + query); the deliverable templates on top
-differ. We ship three universal templates in v0.2 (`weekly` / `brief` /
-`retro`) and user-authored templates in v0.7.
-
-| Scenario | Trigger | Available now (v0.1) | v0.2 deliverable |
-|---|---|---|---|
-| **Knowledge worker / PM / consultant** | Weekly status due; meeting tomorrow | 14 queries by hand | `memexa weekly` / `memexa brief <person>` |
-| **Researcher / student / academic** | Experiment done → write report; defense prep | `arc` + `quick` + `topic` | `memexa brief <topic>` / `memexa retro <window>` |
-| **Content creator / 自媒体** | Idea recovery; weekly material round-up | `topic` + `timeline` | `memexa retro <window>` (+ v0.7 community templates) |
-| **Small business / 个体户** | Client meeting prep; deal recap | `arc` + `project` | `memexa brief <person>` / `memexa retro <window>` |
-| **Self-quantified / GTD / privacy power user** | Daily / weekly review | `memexa pending` | `memexa retro <window>` |
-
-## Six data sources
-
-| Source | Builder | Driver |
-|---|---|---|
-| WeChat | `memexa/ingestion/v5_wechat_batch_builder.py` | `memexa/drivers/backfill_v5_wechat_driver.py` |
-| QQ | `memexa/extraction/qq/qq_history_to_batches.py` | `memexa/drivers/backfill_v5_qq_driver.py` |
-| Email | `memexa/ingestion/v5_email_batch_builder.py` | `memexa/drivers/backfill_v5_email_driver.py` |
-| Browser | `memexa/ingestion/v5_browser_batch_builder.py` | `memexa/drivers/backfill_v5_browser_driver.py` |
-| AI chat (Claude Code) | `memexa/extraction/claude_code_to_v5_converter.py` | `memexa/drivers/backfill_v5_cc_driver.py` |
-| Audio (microphone) | `memexa/ingestion/v5_audio_batch_builder.py` | `memexa/drivers/backfill_v5_audio_driver.py` |
-
-## Quickstart
-
-```bash
-# 1. Install
-pip install -e .
-
-# 2. Initialize config (creates ~/.memexa/ with 3 example files)
-memexa init                          # → ~/.memexa/{aliases,identity}.yaml + .env
-
-# 3. Start the backend
-docker compose -f docker-compose.example.yml up -d
-
-# 4. Run the demo (use --dry-run if backend isn't up yet)
-python -m examples.demo_dataset.ingest --dry-run
-
-# 5. Self-check + first query
-memexa doctor                        # verify backend + LLM provider
-memexa quick "<your keyword>"
-```
-
-Full walkthrough: [docs/quickstart.md](docs/quickstart.md)
-
-## Why memexa instead of OpenHuman or MemPalace?
-
-The Chinese-language data memexa ingests (WeChat / QQ / 飞书 / 钉钉
-multi-party group chats, Chinese audio, Chinese email threads) demands
-something the adjacent OSS memory projects don't provide:
-
-| Capability | OpenHuman (Memory Tree) | MemPalace (Verbatim) | **memexa (V2 envelope)** |
-|---|---|---|---|
-| Storage model | 3k-token markdown hierarchical summaries | Verbatim text + Zettelkasten literal index | **Verbatim raw + LLM-extracted narrative + entities + evidence_quotes + relations + time_resolutions** |
-| Multi-party group-chat role resolution (谁对谁说) | Summary collapses roles | No role concept, literal index only | ✅ V2 envelope `roles[]` + `identity_assertions` |
-| Per-claim source citation back to original text | Summary already folded | ✅ verbatim returns raw | ✅ `evidence_quotes` binds every claim to its source sentence + `chunk_id` + raw batch path |
-| Cross-alias entity canonicalization (`@张三` / `张老师` / `zhangsan@...` → one id) | Names only, no aliases | No entity concept | ✅ `identity_manifest` + `canonical_id` (4-phase, zero-LLM) |
-| Chinese relative-time resolution ("上周三", "前天下午") | Doc-time only, no parsing | None | ✅ `time_resolutions` (ISO 8601 + relative-anchor) |
-| Hallucination control on extraction | None — single-pass summarize | None — no extract | ✅ **Two-LLM gate + extract + DeepSeek arbiter** quorum, schema-validated |
-
-**The thesis**: hierarchical summaries (OpenHuman) lose information for
-high-accuracy tasks; literal-text Zettelkasten (MemPalace) cannot
-disambiguate "who said what to whom when" in a 10-person WeChat
-group-chat history. memexa's V2 envelope keeps both — verbatim raw
-plus an LLM-extracted structured layer with per-claim citation. When a
-deliverable template ([ROADMAP](ROADMAP.md) v0.2) cites a fact, the
-user can drill back to the exact original quote in seconds, with the
-group-chat speaker correctly identified across all aliases.
-
-This is the lane memexa actually owns. The Chinese-IM data sources
-([ROADMAP](ROADMAP.md) v0.3) are how that lane reaches users; the
-deliverable templates ([ROADMAP](ROADMAP.md) v0.2) are how it pays off.
-
-## Two-LLM gate-extract architecture
-
-```
-┌──────────────────────────────────────────────────────────────────────┐
-│  6 categories of Chinese-language data                               │
-│  WeChat │ QQ │ Email │ Browser │ AI chat │ Voice memo                │
-└──────────────────────────────────────────────────────────────────────┘
-                                  ▼
-┌──────────────────────────────────────────────────────────────────────┐
-│  Per-source batch builder  →  JSON envelopes                         │
-└──────────────────────────────────────────────────────────────────────┘
-                                  ▼
-┌──────────────────────────────────────────────────────────────────────┐
-│  Stage A: gatekeeper LLM  (filter HIGH/MEDIUM/LOW)                   │
-│  Stage B: extractor LLM   (V2 envelope JSON)                         │
-│  Stage C: BGE-M3 quorum + arbiter                                    │
-│  Stage D: POST → memory_full_v5 bank                                 │
-└──────────────────────────────────────────────────────────────────────┘
-                                  ▼
-┌──────────────────────────────────────────────────────────────────────┐
-│  PostgreSQL + pgvector + BGE-M3 embeddings + temporal links          │
-└──────────────────────────────────────────────────────────────────────┘
-                                  ▼
-┌──────────────────────────────────────────────────────────────────────┐
-│  14 query subcommands + 5-phase state inference + deliverable layer  │
-└──────────────────────────────────────────────────────────────────────┘
-```
-
-Full architecture: [docs/architecture.md](docs/architecture.md)
-
-## Query CLI
-
-```bash
-memexa <subcmd> "<query>" [options]
-```
-
-14 subcommands in three tiers (basic / advanced / composite). The 8 most common:
-
-| Subcommand | Use case |
+| Topic | Link |
 |---|---|
-| `quick` | "Who is X" — point query |
-| `topic` | "The whole story of X" — theme expansion (DO NOT use on names! see hard rules) |
-| `arc` | "How did I meet X" — relationship arc (preferred for names) |
-| `timeline` | "What happened during this period?" — temporal |
-| `person` | "Status of professor Y" — person profile |
-| `project` | "Cross-source pulse of project Z" |
-| `pending` | "What's on my plate" — active commitments |
-| `reflect` | LLM-synthesized answer |
-
-Full usage: [docs/usage_guide.md](docs/usage_guide.md)
-
-## 📖 Example walkthroughs — 5 reproducible scenarios
-
-> Install → `make demo-ingest` → follow a walkthrough → see memexa in action.
-> Everything runs on a synthetic dataset (Alice / Bob / Carol /
-> advisor@example.com). Anyone can reproduce 1:1, **no real personal data**.
-
-```
-┌────────────────────────────────────────────────────────────────────┐
-│                  What question are you asking?                     │
-└────────────────────────────────────────────────────────────────────┘
-        │                    │                    │
-        ▼                    ▼                    ▼
-   "Who is X?"        "Group activity last week?"  "What's on my plate?"
-   01_who_is_alice    02_weekly_team               05_my_pending
-   arc + quick         topic + trends               pending + quick
-        │                    │                    │
-        ▼                    ▼                    ▼
-   "What does Y want?" "Project X status?"
-   04_advisor_said     03_project_status
-   person              project + timeline
-```
-
-**5 walkthroughs** (5–10 min each):
-
-| # | Walkthrough | Scenario | Command combo |
-|---|---|---|---|
-| [01](examples/demo_dataset/walkthroughs/01_who_is_alice.md) | Who is Alice? | "How do I know X?" | `arc` + `quick` |
-| [02](examples/demo_dataset/walkthroughs/02_weekly_team_summary.md) | Weekly team summary | "What did the group do last week?" | `topic` + `trends` |
-| [03](examples/demo_dataset/walkthroughs/03_project_status_check.md) | Project status check | "Where is project X?" | `project` + `timeline` |
-| [04](examples/demo_dataset/walkthroughs/04_what_did_advisor_say.md) | What did advisor say? | "What does Y (advisor/boss) want?" | `person` |
-| [05](examples/demo_dataset/walkthroughs/05_my_pending_actions.md) | My pending actions | "What's on my plate?" | `pending` + `quick` |
-
-**2 case studies** (methodology, 10–15 min each):
-
-| # | Case study | Audience | Output |
-|---|---|---|---|
-| [01](docs/case_studies/01_lab_report_pipeline.md) | Late-bound deliverable pipeline | Anyone recovering from a missed deadline | LaTeX → PDF + action card (20 min end-to-end) |
-| [02](docs/case_studies/02_meeting_brief_pattern.md) | 5-minute meeting brief | Anyone prepping for a meeting | 4-section Markdown brief (5 min end-to-end) |
-
-→ Index pages: [`examples/demo_dataset/walkthroughs/`](examples/demo_dataset/walkthroughs/) · [`docs/case_studies/`](docs/case_studies/)
+| Quickstart (3-tier path: 30 s → 5 min → 30 min) | [`docs/quickstart.md`](docs/quickstart.md) |
+| Architecture | [`docs/architecture.md`](docs/architecture.md) |
+| Why memexa (vs OpenHuman / MemPalace; 5 user scenarios) | [`docs/why.md`](docs/why.md) |
+| Cost estimation (DeepSeek / GPT-4o / Claude monthly) | [`docs/cost.md`](docs/cost.md) |
+| 14 query subcommands in depth | [`docs/usage_guide.md`](docs/usage_guide.md) |
+| 5-phase state inference | [`docs/5_phase_query.md`](docs/5_phase_query.md) |
+| Full environment variables | [`docs/configuration.md`](docs/configuration.md) |
+| FAQ / troubleshooting | [`docs/faq.md`](docs/faq.md) · [`docs/troubleshooting.md`](docs/troubleshooting.md) |
+| Per-source onboarding | [`docs/integrations/`](docs/integrations/) |
+| Cross-platform deployment | [`docs/deployment/`](docs/deployment/) |
+| Example walkthroughs (synthetic data) | [`examples/demo_dataset/walkthroughs/`](examples/demo_dataset/walkthroughs/) |
+| Case studies | [`docs/case_studies/`](docs/case_studies/) |
+| **For AI agents (MCP / integration spec)** | [`docs/for_agents.md`](docs/for_agents.md) |
+| Roadmap | [`ROADMAP.md`](ROADMAP.md) |
+| Contributing | [`CONTRIBUTING.md`](CONTRIBUTING.md) |
+| Security policy | [`SECURITY.md`](SECURITY.md) |
+| Governance | [`GOVERNANCE.md`](GOVERNANCE.md) |
 
 ## Two ways to run the LLM
 
-memexa's core is a two-LLM extract pipeline. The OSS ships everything you need
-to run it locally.
+memexa's core is a two-LLM gate-extract pipeline. The OSS ships
+everything you need to run it locally with any OpenAI-compatible
+endpoint.
 
 ```bash
-# Default: OSS bundled prompt + your own LLM provider
-#   Set OpenAI / DeepSeek / local vLLM base_url + key in .env
+# Default: bundled prompts + your own LLM provider
 export MEMEXA_EXTRACTOR_TIER=bundled
 
-# BYO: bring your own prompt (for advanced users with existing prompt tuning)
+# BYO: bring your own prompt for advanced tuning
 export MEMEXA_EXTRACTOR_TIER=byo
 export MEMEXA_PROMPT_PATH=/path/to/your_prompts.py
 ```
 
-**Roadmap**: v0.5 will add an optional paid API endpoint, billed per token
-(OpenAI-style, no subscription). This is an upgrade path, **not a gate** —
-the OSS stays fully usable forever. See [docs/api_roadmap.md](docs/api_roadmap.md).
-
-## Documentation index
-
-| Topic | Link |
-|---|---|
-| 30-minute first run | [docs/quickstart.md](docs/quickstart.md) |
-| Architecture | [docs/architecture.md](docs/architecture.md) |
-| 14 query subcommands in depth | [docs/usage_guide.md](docs/usage_guide.md) |
-| 5-phase state inference | [docs/5_phase_query.md](docs/5_phase_query.md) |
-| Full environment variables | [docs/configuration.md](docs/configuration.md) |
-| FAQ | [docs/faq.md](docs/faq.md) |
-| Troubleshooting | [docs/troubleshooting.md](docs/troubleshooting.md) |
-| Performance numbers | [docs/performance.md](docs/performance.md) |
-| Per-source onboarding | [docs/integrations/](docs/integrations/) |
-| macOS / Windows / Linux deployment | [docs/deployment/](docs/deployment/) |
-| **Example walkthroughs (synthetic data)** | [examples/demo_dataset/walkthroughs/](examples/demo_dataset/walkthroughs/) |
-| **Case studies (methodology)** | [docs/case_studies/](docs/case_studies/) |
-| **🤖 For AI agents (protocol doc)** | [docs/for_agents.md](docs/for_agents.md) |
-| Paid API endpoint (roadmap) | [docs/api_roadmap.md](docs/api_roadmap.md) |
-| Engineering lessons learned | [docs/lessons_learned/](docs/lessons_learned/) |
-| Contribution guide | [CONTRIBUTING.md](CONTRIBUTING.md) |
-| Code of conduct | [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) |
-| Security policy | [SECURITY.md](SECURITY.md) |
-| Governance | [GOVERNANCE.md](GOVERNANCE.md) |
-| Roadmap | [ROADMAP.md](ROADMAP.md) |
-| Support | [SUPPORT.md](SUPPORT.md) |
-| Citation | [CITATION.cff](CITATION.cff) |
+Recommended provider for Chinese workloads is DeepSeek V4 Flash (gate)
++ V4 Pro (extractor) — typical cost is **¥0.30 per 1 000 messages**.
+GPT-4o and Claude 4.x are supported but cost 5–10× more.
+See [`docs/cost.md`](docs/cost.md) for the full breakdown.
 
 ## License
 
-Apache 2.0. See [LICENSE](LICENSE).
-
-OSS core = Apache 2.0, unrestricted commercial use. The optional paid API
-endpoint, when it ships, will have its own service terms — see
-[docs/api_roadmap.md](docs/api_roadmap.md).
+Apache 2.0. See [`LICENSE`](LICENSE). OSS core stays Apache 2.0
+forever.

--- a/README.zh.md
+++ b/README.zh.md
@@ -19,265 +19,142 @@ repository-topics:
 
 [English](README.md) · **中文**
 
-> **Your personal Pensieve.**
-> 把你散落在 6 个 silo 的数据，按你当下要做的事，编成一份能直接交付/带走的文档。
+> **面向 AI agent 与人类共用、中文原生数据的 memory layer。**
+> 自托管 memory graph, 覆盖微信 / QQ / 飞书 / 钉钉 群聊、中文邮件、
+> 中文音频。Verbatim 存储 + 结构化抽取; 查询返回带原句 citation 的
+> cards。
+>
+> 🤖 **设计上就是 AI agent 兼容的**。绝大多数真实用法 = AI agent
+> (Claude Code / Cursor / Cline / 自写 agent) 把 memexa 当 subprocess
+> 调, 代用户回答问题。14 个查询子命令是个小协议; agent 需要遵守的
+> 契约写在 [`docs/for_agents.zh.md`](docs/for_agents.zh.md)。原生 MCP
+> integration 在 v0.5; 当前 first-class 路径 = shell subprocess +
+> `--json` 输出。
 
 [![CI](https://github.com/labazhou2024/memexa/actions/workflows/ci.yml/badge.svg)](https://github.com/labazhou2024/memexa/actions/workflows/ci.yml)
 [![CodeQL](https://github.com/labazhou2024/memexa/actions/workflows/codeql.yml/badge.svg)](https://github.com/labazhou2024/memexa/actions/workflows/codeql.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](pyproject.toml)
-[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![PyPI](https://img.shields.io/pypi/v/memexa?label=PyPI)](https://pypi.org/project/memexa/)
 [![PII scan](https://img.shields.io/badge/PII%20residual-0%20matches-success.svg)](scripts/full_pii_scan.sh)
-
-## 这是什么
-
-`memexa` 摄入你 6 类中文日常数据（微信、QQ、邮件、浏览、AI 对话、语音备忘），
-用双 LLM 抽取实体 / 关系 / 时间证据，存进 PostgreSQL + pgvector 记忆图谱，
-然后用 **14 个查询子命令** 把当下要用的东西捞出来 — 谁找过我？这件事的全过程？
-我有哪些待办？X 项目跨源动态？
-
-灵感来自《哈利波特》的冥想盆（Pensieve）—— 把脑子里散落的记忆倒出来，
-重组、观察、抽取出当下要用的东西。
-
-```
-   微信 ─┐                                         ┌─► "X 是谁?"           (arc + quick)
-   QQ   ─┤                                         ├─► "上周组里干了啥?"   (topic + trends)
-   邮件 ─┼──► 双 LLM 抽取 ──► PG + pgvector ──┤
-   浏览 ─┤    (gate+extract)   记忆图谱        ├─► "X 项目到哪了?"     (project + timeline)
-   AI   ─┤                                         ├─► "Y 老师要啥?"       (person)
-   语音 ─┘                                         └─► "我有哪些待办?"     (pending)
-        ↑                                                  ↑
-   你的原始数据                                       14 个查询子命令
-   (本地, 完全自托管)                                  (cross-source 组合)
-```
-
-> **v0.1 范围**: 完整 ingestion + 抽取 + 查询 + dashboard + **5 篇 walkthrough + 2 篇 case study**。
-> 上层"按用途自动生成可交付物"在 [ROADMAP.md](ROADMAP.md) v0.2，
-> 以**三个通用模板** ship — `weekly` / `brief` / `retro` —
-> 覆盖 5 类用户场景（知识工作者 / 研究者 / 创作者 / 中小企业主 / GTD）。
-> v0.7 开放用户自定义模板, 交付层升级为生态。
-> v0.1 阶段先用 14 个查询命令手动组合得到大致效果。
->
-> 🚀 **第一次看？** 直接跳 [Example walkthroughs ↓](#-example-walkthroughs--5-个-reproducible-实例) 看 5 个真实场景怎么用。
-
-> 🤖 **设计上就是 AI agent 兼容的**。绝大多数真实用户是让 AI agent
-> (Claude Code / Cursor / Cline / 自己写的 agent) 替自己调用 memexa,
-> 而不是手敲子命令。14 个查询子命令是一个小协议; 给 agent 的协议文档在
-> [docs/for_agents.zh.md](docs/for_agents.zh.md) (硬规则 / 决策表 /
-> 组合模式 / 常见坑)。如果你在做需要中文数据记忆层的 agent, 从那开始。
-
-## 5 类用户场景 (面向中文整个市场的设计)
-
-memexa 面向**整个中文市场**，不局限于某个单一群体。5 类场景共用同一套
-底层（ingestion + 双 LLM 抽取 + 图谱 + 查询）；上层交付物模板按场景出
-不同输出。v0.2 ship 3 个最通用的模板（`weekly` / `brief` / `retro`），
-v0.7 开放用户自定义模板。
-
-| 用户场景 | 触发情境 | 当下可用 (v0.1) | v0.2 交付物 |
-|---|---|---|---|
-| **知识工作者 / PM / 咨询** | 周报到期；明天有会 | 14 个 query 手动组合 | `memexa weekly` / `memexa brief <人>` |
-| **研究者 / 学生 / 学者** | 实验做完 → 写报告；答辩准备 | `arc` + `quick` + `topic` | `memexa brief <主题>` / `memexa retro <时段>` |
-| **内容创作者 / 自媒体** | 灵感回收；周素材整理 | `topic` + `timeline` | `memexa retro <时段>` (+ v0.7 社区模板) |
-| **中小企业主 / 个体户** | 客户见面准备；交易复盘 | `arc` + `project` | `memexa brief <人>` / `memexa retro <时段>` |
-| **自我量化 / GTD / 隐私用户** | 每日 / 每周回顾 | `memexa pending` | `memexa retro <时段>` |
-
-## 6 个数据源
-
-| Source | Builder | Driver |
-|---|---|---|
-| 微信 WeChat | `memexa/ingestion/v5_wechat_batch_builder.py` | `memexa/drivers/backfill_v5_wechat_driver.py` |
-| QQ | `memexa/extraction/qq/qq_history_to_batches.py` | `memexa/drivers/backfill_v5_qq_driver.py` |
-| 邮件 Email | `memexa/ingestion/v5_email_batch_builder.py` | `memexa/drivers/backfill_v5_email_driver.py` |
-| 浏览历史 Browser | `memexa/ingestion/v5_browser_batch_builder.py` | `memexa/drivers/backfill_v5_browser_driver.py` |
-| AI 对话 Claude Code | `memexa/extraction/claude_code_to_v5_converter.py` | `memexa/drivers/backfill_v5_cc_driver.py` |
-| 语音 Audio (mic) | `memexa/ingestion/v5_audio_batch_builder.py` | `memexa/drivers/backfill_v5_audio_driver.py` |
 
 ## Quickstart
 
-```bash
-# 1. 装包
-pip install -e .
+2 个起点, 按你身份选。
 
-# 2. 初始化配置 (创建 ~/.memexa/ + 3 个示例文件)
-memexa init                          # → ~/.memexa/{aliases,identity}.yaml + .env
-
-# 3. 起后端
-docker compose -f docker-compose.example.yml up -d
-
-# 4. 跑 demo (不连后端可用 --dry-run)
-python -m examples.demo_dataset.ingest --dry-run
-
-# 5. 自检 + 第一次查询
-memexa doctor                        # 验证后端 + LLM provider
-memexa quick "<你的关键词>"
-```
-
-完整步骤: [docs/quickstart.zh.md](docs/quickstart.zh.md)
-
-## 为什么不直接用 OpenHuman 或 MemPalace？
-
-memexa 摄入的中文数据（微信 / QQ / 飞书 / 钉钉 多人群聊、中文音频、
-中文邮件长链）要求一种相邻 OSS memory 项目不提供的能力：
-
-| 能力 | OpenHuman (Memory Tree) | MemPalace (Verbatim) | **memexa (V2 envelope)** |
-|---|---|---|---|
-| 存储模式 | 3k-token markdown 层级摘要 | Verbatim 全文 + Zettelkasten 字面索引 | **Verbatim 原始 + LLM 抽取的 narrative + entities + evidence_quotes + relations + time_resolutions** |
-| 多人群聊角色解析（谁对谁说） | summary 折叠掉角色 | 无 role 概念, 只字面索引 | ✅ V2 envelope `roles[]` + `identity_assertions` |
-| 每条断言可回溯到原文一句话 | summary 已折叠 | ✅ verbatim 直接回 | ✅ `evidence_quotes` 把每条 claim 绑回原句 + `chunk_id` + 原始 batch 路径 |
-| 跨别名实体收敛（`@张三` / `张老师` / `zhangsan@...` → 一个 id） | 只到人名, 不抽别名 | 无 entity 概念 | ✅ `identity_manifest` + `canonical_id` (4 阶段 0-LLM 算法) |
-| 中文相对时间解析（"上周三"、"前天下午"） | 只看文档时间, 不解析 | 无 | ✅ `time_resolutions` (ISO 8601 + 相对锚点) |
-| 抽取幻觉控制 | 无 — 单次摘要 | 无 — 不抽取 | ✅ **双 LLM gate + extract + DeepSeek arbiter** 仲裁, schema 校验 |
-
-**论点**: 层级摘要（OpenHuman）必然丢信息, 对高准确度任务不够;
-字面 Zettelkasten（MemPalace）无法在 10 人微信群聊里区分"谁
-在什么时候对谁说了什么"。memexa 的 V2 envelope 两者兼得 — 既存
-verbatim 原始, 又保留 LLM 抽取的结构化层 + 每条断言的原文引用。
-当 v0.2 交付模板引用一个事实时, 用户能秒级回到原句, 群聊说话者
-在所有别名间被正确识别。
-
-这是 memexa 真正占据的赛道。中文 IM 数据源（v0.3）是这条赛道
-触达用户的方式; 交付模板（v0.2）是这条赛道兑现价值的方式。
-
-## 双 LLM gate-extract 架构
-
-```
-┌──────────────────────────────────────────────────────────────────────┐
-│  6 类中文数据                                                          │
-│  微信 │ QQ │ 邮件 │ 浏览 │ AI 对话 │ 语音备忘                          │
-└──────────────────────────────────────────────────────────────────────┘
-                                  ▼
-┌──────────────────────────────────────────────────────────────────────┐
-│  Per-source batch builder  →  JSON envelopes                         │
-└──────────────────────────────────────────────────────────────────────┘
-                                  ▼
-┌──────────────────────────────────────────────────────────────────────┐
-│  Stage A: gatekeeper LLM  (筛 HIGH/MEDIUM/LOW)                         │
-│  Stage B: extractor LLM   (V2 envelope JSON)                          │
-│  Stage C: BGE-M3 quorum + arbiter                                     │
-│  Stage D: POST → memory_full_v5 bank                                  │
-└──────────────────────────────────────────────────────────────────────┘
-                                  ▼
-┌──────────────────────────────────────────────────────────────────────┐
-│  PostgreSQL + pgvector + BGE-M3 embeddings + temporal links          │
-└──────────────────────────────────────────────────────────────────────┘
-                                  ▼
-┌──────────────────────────────────────────────────────────────────────┐
-│  14 个查询命令 + 5-phase 状态推理 + Deliverable templates              │
-└──────────────────────────────────────────────────────────────────────┘
-```
-
-完整架构: [docs/architecture.zh.md](docs/architecture.zh.md)
-
-## 查询 CLI
+### 人类用户 — 30 秒看见
 
 ```bash
-memexa <subcmd> "<query>" [options]
+pip install --pre memexa
+memexa demo
 ```
 
-14 个子命令分三档（基础 / 高级 / 复合链）。最常用的 8 个：
+你会看到 6 个 source 的合成对话被 stub extractor 摄入, 接着 5 个示例
+查询在终端打印 — `quick` / `arc` / `timeline` / `pending` / `topic`。
+不需要后端, 不需要 LLM, 不需要配置。这是项目实际能做什么的第一眼诚实
+展示。
 
-| Subcommand | 用例 |
+### AI agent — 今天 subprocess CLI, v0.5 再上 MCP
+
+```bash
+# Agent 今天通过 subprocess 已经能用:
+pip install --pre memexa
+memexa quick "<你的问题>" --json   # 结构化输出方便 agent parse
+memexa arc "<人名>" --json
+# ... 共 14 个子命令, 全部 v0.1.x 起支持 --json mode
+```
+
+14 个子命令 + [`docs/for_agents.zh.md`](docs/for_agents.zh.md) 的 7
+条 hard rule 是 agent 契约。原生 MCP integration (`memexa-mcp` server +
+`.mcp.json` snippet) 在 v0.5; 在此之前 shell subprocess 是 first-class
+路径, 任何能跑 shell 工具的 agent 都能用。
+
+### 接下来 (对人和 agent 都适用)
+
+要接自己的数据, 配 LLM provider 选 1 个 source 开始。
+[`docs/quickstart.zh.md`](docs/quickstart.zh.md) 走 Tier 1 (5 分钟,
+1 个 source) 和 Tier 2 (30 分钟, 完整生产部署 + cron + dashboard)。
+
+## 你可以问什么
+
+| 问题 pattern | 子命令 | 返回 |
+|---|---|---|
+| X 是谁 | `arc "X"` | 关系演化, 8 个 fan-out 变体 |
+| X 的全过程 | `topic "Mac 购置"` | 80-200 张带 citation 的 cards |
+| Y 老师最近要什么 | `person "Y 老师"` | 人物 article + 近期 events |
+| X 项目跨源动态 | `project "X"` | 4 个 source 各 N 张 |
+| 我有哪些待办 | `pending` | 日历活跃 commitments |
+| 这段时间发生了什么 | `timeline --start ... --end ...` | 时序卡片列表 |
+| 综合回答 | `reflect "问题"` | LLM 综合 Markdown |
+
+共 14 个子命令。决策表和组合模式在
+[`docs/usage_guide.zh.md`](docs/usage_guide.zh.md)。yes/no 状态查询的
+5-phase 工作流见 [`docs/5_phase_query.zh.md`](docs/5_phase_query.zh.md)。
+
+## 为什么用 memexa, 不用 OpenHuman / MemPalace / ReMe?
+
+简短: verbatim 原始存储 + LLM 抽取 V2 envelope + 每条断言
+`evidence_quotes` 原文 citation + 跨别名 canonical id, 全部在相邻项目
+不打算碰的中文 IM 数据源上。
+
+完整逐项能力对比和 5 类用户场景见 [`docs/why.zh.md`](docs/why.zh.md)。
+
+## 架构一图
+
+```
+   微信   ─┐                                              ┌─► "X 是谁?"           (arc + quick)
+   QQ     ─┤                                              ├─► "上周组里干啥?"     (topic + trends)
+   邮件   ─┼──► 双 LLM 抽取 ──► PG + pgvector ──┤
+   浏览   ─┤    (gate+extract)   记忆图谱        ├─► "X 项目到哪了?"     (project + timeline)
+   AI 对话─┤                                              ├─► "Y 老师要啥?"       (person)
+   语音   ─┘                                              └─► "我有哪些待办?"     (pending)
+        ↑                                                       ↑
+   原始数据                                              14 个查询子命令
+   (本地, 完全自托管)                                    (跨源组合)
+```
+
+完整架构见 [`docs/architecture.zh.md`](docs/architecture.zh.md)。
+
+## 文档导航
+
+| 主题 | 链接 |
 |---|---|
-| `quick` | "X 是谁" 点查 |
-| `topic` | "X 的全过程" 主题展开 (人名禁用！见 hard rule) |
-| `arc` | "我和 X 怎么认识" 关系演化 (人名首选) |
-| `timeline` | "X 这段时间发生啥" 时序 |
-| `person` | "Y 老师近况" 人物档 |
-| `project` | "Z 项目跨源动态" |
-| `pending` | "我有哪些待办" 主动 commitment |
-| `reflect` | LLM 综合答案 |
+| Quickstart (3-tier 路径: 30 秒 → 5 分钟 → 30 分钟) | [`docs/quickstart.zh.md`](docs/quickstart.zh.md) |
+| 架构 | [`docs/architecture.zh.md`](docs/architecture.zh.md) |
+| 为什么用 memexa (对比 / 5 用户场景) | [`docs/why.zh.md`](docs/why.zh.md) |
+| 成本估算 (DeepSeek / GPT-4o / Claude 月度) | [`docs/cost.zh.md`](docs/cost.zh.md) |
+| 14 个查询子命令详解 | [`docs/usage_guide.zh.md`](docs/usage_guide.zh.md) |
+| 5-phase 状态推断 | [`docs/5_phase_query.zh.md`](docs/5_phase_query.zh.md) |
+| 完整环境变量 | [`docs/configuration.zh.md`](docs/configuration.zh.md) |
+| FAQ / 故障排查 | [`docs/faq.zh.md`](docs/faq.zh.md) · [`docs/troubleshooting.zh.md`](docs/troubleshooting.zh.md) |
+| 各 source 接入指南 | [`docs/integrations/`](docs/integrations/) |
+| 跨平台部署 | [`docs/deployment/`](docs/deployment/) |
+| 示例 walkthrough (合成数据) | [`examples/demo_dataset/walkthroughs/`](examples/demo_dataset/walkthroughs/) |
+| Case studies | [`docs/case_studies/`](docs/case_studies/) |
+| **AI agent 接入 (MCP / integration spec)** | [`docs/for_agents.zh.md`](docs/for_agents.zh.md) |
+| 路线图 | [`ROADMAP.zh.md`](ROADMAP.zh.md) |
+| 贡献指南 | [`CONTRIBUTING.zh.md`](CONTRIBUTING.zh.md) |
+| 安全策略 | [`SECURITY.zh.md`](SECURITY.zh.md) |
+| 治理 | [`GOVERNANCE.md`](GOVERNANCE.md) |
 
-完整用法: [docs/usage_guide.zh.md](docs/usage_guide.zh.md)
+## 两种 LLM 运行方式
 
-## 📖 Example walkthroughs — 5 个 reproducible 实例
-
-> 装包 → `make demo-ingest` → 跟着 walkthrough 跑命令 → 看 memexa 实际怎么工作。
-> 全程基于合成 demo dataset (Alice / Bob / Carol / advisor@example.com)，
-> 任何人 1:1 复现，**没有任何真实个人数据**。
-
-```
-┌────────────────────────────────────────────────────────────────────┐
-│                      你想回答的问题是…                              │
-└────────────────────────────────────────────────────────────────────┘
-        │                    │                    │
-        ▼                    ▼                    ▼
-   "X 是谁?"           "上周组里在干嘛?"      "我这周要做啥?"
-   01_who_is_alice     02_weekly_team        05_my_pending
-   arc + quick          topic + trends        pending + quick
-        │                    │                    │
-        ▼                    ▼                    ▼
-   "Y 老师要啥?"       "X 项目到哪了?"
-   04_advisor_said     03_project_status
-   person              project + timeline
-```
-
-**5 个 walkthrough** (每个 5-10 min 看完):
-
-| # | Walkthrough | 触发场景 | 命令组合 |
-|---|---|---|---|
-| [01](examples/demo_dataset/walkthroughs/01_who_is_alice.zh.md) | Alice 是谁? | "我和 X 关系怎样" | `arc` + `quick` |
-| [02](examples/demo_dataset/walkthroughs/02_weekly_team_summary.zh.md) | 组里上周干了啥 | "上周组里干了啥" | `topic` + `trends` |
-| [03](examples/demo_dataset/walkthroughs/03_project_status_check.zh.md) | 项目到哪了 | "X 项目到哪了" | `project` + `timeline` |
-| [04](examples/demo_dataset/walkthroughs/04_what_did_advisor_say.zh.md) | 导师/老板要啥 | "Y 老师/老板要啥" | `person` |
-| [05](examples/demo_dataset/walkthroughs/05_my_pending_actions.zh.md) | 我有哪些待办 | "我有哪些待办" | `pending` + `quick` |
-
-**2 篇 case study** (方法论，10-15 min 各看完):
-
-| # | Case study | 适合谁 | 输出 |
-|---|---|---|---|
-| [01](docs/case_studies/01_lab_report_pipeline.zh.md) | 错过 ddl 补救流水线 | 错过 ddl 要交报告的人 | LaTeX → PDF + 行动卡 (20 min 端到端) |
-| [02](docs/case_studies/02_meeting_brief_pattern.zh.md) | 5 分钟见面简报模板 | 见某人前要"脑暖"的人 | 4 段 Markdown brief (5 min 端到端) |
-
-→ 索引页: [`examples/demo_dataset/walkthroughs/`](examples/demo_dataset/walkthroughs/README.zh.md) · [`docs/case_studies/`](docs/case_studies/README.zh.md)
-
-## 两种跑 LLM 的方式
-
-`memexa` 的核心是双 LLM 抽取 pipeline。OSS 完整自带，可以本地跑。
+memexa 的核心是双 LLM gate-extract 流程。OSS ship 了你本地用任何 OpenAI
+兼容 endpoint 跑它需要的一切。
 
 ```bash
-# 默认：OSS bundled prompt + 你自己的 LLM provider
-#   你只要在 .env 设置 OpenAI / DeepSeek / 本地 vLLM 的 base_url + key
+# 默认: 内置 prompt + 你自己的 LLM provider
 export MEMEXA_EXTRACTOR_TIER=bundled
 
-# BYO：你自填 prompt（已有自己 prompt 工程的高级用户）
+# BYO: 自带 prompt 做高级调优
 export MEMEXA_EXTRACTOR_TIER=byo
 export MEMEXA_PROMPT_PATH=/path/to/your_prompts.py
 ```
 
-**路线图**：v0.5 会上线一个可选的付费 API endpoint，
-按 token 计费（OpenAI-style，无订阅）。这是个增值入口，
-**不影响 OSS 完整可用**。详见 [docs/api_roadmap.zh.md](docs/api_roadmap.zh.md)。
-
-## 文档索引
-
-| 主题 | 链接 |
-|---|---|
-| 30 分钟首次跑通 | [docs/quickstart.zh.md](docs/quickstart.zh.md) |
-| 架构设计 | [docs/architecture.zh.md](docs/architecture.zh.md) |
-| 14 个查询命令详解 | [docs/usage_guide.zh.md](docs/usage_guide.zh.md) |
-| 5-phase 状态推理 | [docs/5_phase_query.zh.md](docs/5_phase_query.zh.md) |
-| 完整环境变量 | [docs/configuration.zh.md](docs/configuration.zh.md) |
-| 常见问题 | [docs/faq.zh.md](docs/faq.zh.md) |
-| 故障排查 | [docs/troubleshooting.zh.md](docs/troubleshooting.zh.md) |
-| 性能数据 | [docs/performance.zh.md](docs/performance.zh.md) |
-| 6 个 source 接入指南 | [docs/integrations/](docs/integrations/) |
-| macOS / Windows / Linux 部署 | [docs/deployment/](docs/deployment/) |
-| **Example walkthroughs (合成数据)** | [examples/demo_dataset/walkthroughs/](examples/demo_dataset/walkthroughs/README.zh.md) |
-| **Case studies (方法论)** | [docs/case_studies/](docs/case_studies/README.zh.md) |
-| **🤖 给 AI agent (协议文档)** | [docs/for_agents.zh.md](docs/for_agents.zh.md) |
-| 付费 API endpoint (roadmap) | [docs/api_roadmap.zh.md](docs/api_roadmap.zh.md) |
-| 工程踩坑总结 | [docs/lessons_learned/](docs/lessons_learned/) |
-| 贡献指南 | [CONTRIBUTING.zh.md](CONTRIBUTING.zh.md) |
-| 行为准则 | [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) |
-| 安全政策 | [SECURITY.zh.md](SECURITY.zh.md) |
-| 治理 | [GOVERNANCE.md](GOVERNANCE.md) |
-| Roadmap | [ROADMAP.zh.md](ROADMAP.zh.md) |
-| Support | [SUPPORT.zh.md](SUPPORT.zh.md) |
-| Citation | [CITATION.cff](CITATION.cff) |
+中文场景推荐 DeepSeek V4 Flash (gate) + V4 Pro (extractor) — 典型成本
+**每 1000 条消息 ¥0.30**。GPT-4o 和 Claude 4.x 也支持, 但成本贵 5-10
+倍。完整对比见 [`docs/cost.zh.md`](docs/cost.zh.md)。
 
 ## License
 
-Apache 2.0. See [LICENSE](LICENSE).
-
-OSS 内核 = Apache 2.0，无限制商用。可选的付费 API endpoint 当未来上线时
-会有独立服务条款，见 [docs/api_roadmap.zh.md](docs/api_roadmap.zh.md)。
+Apache 2.0. See [`LICENSE`](LICENSE). OSS core 永远 Apache 2.0。

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,283 +4,212 @@
 
 > Aspirational. Not a commitment. Things move when they move.
 
-## Positioning (revised 2026-05-16)
+## Positioning
 
-**Stated goal: become the #1 OSS memory-graph project in China for
-Chinese-native multi-party data.**
+memexa is a self-hosted memory graph for Chinese-native multi-party
+data — WeChat / QQ / 飞书 / 钉钉 group chats, Chinese email threads,
+Chinese audio recordings. Each message is stored verbatim and
+extracted into a structured envelope (narrative + entities +
+per-claim evidence quotes + time resolutions + relation assertions)
+using a two-LLM pipeline. Queries cross sources, return cards with
+citations, and feed into deliverable templates.
 
-memexa targets **the broader Chinese-speaking market** — *not* a single
-demographic. Two compounding moats:
+The project occupies a lane the adjacent OSS memory projects do not
+address: Chinese-native data sources, high-accuracy citation back to
+source sentences, and CLI-first design usable by both humans and AI
+agents.
 
-1. **Chinese-native data sources**: WeChat / QQ / 飞书 / 钉钉 multi-party
-   group chats, Chinese audio, Chinese email threads — OpenHuman /
-   MemPalace's Western-SaaS-OAuth + summary / verbatim model can't
-   handle these well.
-2. **V2 envelope extraction with per-claim citation**: verbatim raw +
-   LLM-extracted narrative + `evidence_quotes` + `identity_assertions`
-   + `time_resolutions` + `relation_assertions`. Hierarchical summaries
-   (OpenHuman) lose information; literal Zettelkasten (MemPalace)
-   can't resolve "who said what to whom" in group chats. memexa keeps
-   both layers and binds every claim back to its source sentence.
+For the per-capability comparison against neighbouring projects
+(OpenHuman, MemPalace, ReMe) and the five user scenarios memexa is
+designed for, see [docs/why.md](docs/why.md).
 
-Adjacent OSS projects (OpenHuman, MemPalace, ReMe) cover the English /
-Western-SaaS / desktop-assistant / dev-tool-MCP lanes. memexa stays in
-the Chinese-native + high-accuracy-citation lane on purpose.
+## Current state (v0.1.0-rc2 on PyPI, 2026-05-16)
 
-**Five user scenarios memexa is designed for:**
+Shipped:
 
-| Scenario | Typical user | Primary deliverable |
-|---|---|---|
-| Knowledge worker / PM / consultant | bilingual office worker, freelancer | `weekly` (cross-source weekly report), `brief <person>` (meeting prep) |
-| Researcher / student / academic | university student, research-track grad student | `brief <topic>` (defense / talk prep), `retro <window>` (project recap) |
-| Content creator / 自媒体 | 公众号 author, 知乎 answerer, Xiaohongshu creator | `retro <window>` (idea recovery), upcoming `notebook` deliverable |
-| Small business / 个体户 | freelance professional, small studio owner | `brief <person>` (client / lead prep), `retro <window>` (deal recap) |
-| Self-quantified / GTD / privacy power user | self-hosted enthusiast, GTD practitioner | `pending` (cross-source to-do), `retro <window>` (weekly review) |
+- CLI: `init` / `version` / `config` / `doctor` / `query`.
+- Fourteen query subcommands (nine basic + five advanced).
+- Six ingestion sources: WeChat, QQ, email, browser, Claude Code, audio.
+- Two-LLM gate-extract pipeline with DeepSeek arbiter quorum.
+- PostgreSQL + pgvector backend (Hindsight FastAPI in docker compose).
+- Live dashboard on port 8765 with seven panels.
+- Deployment guides for macOS, Windows, and Linux + Docker.
+- Eight tests, nineteen CI workflow checks, CodeQL clean.
+- Dependabot security alerts and automated security fixes enabled.
+- Fresh-clone smoke test passes on Win + macOS + Linux ×
+  Python 3.10 / 3.11 / 3.12.
 
-All five share the same backbone (ingestion + extract + graph + query +
-deliverable templates). Templates differ; we ship the three most
-universal (`weekly` / `brief` / `retro`) in v0.2 and let users author
-their own in v0.7.
+Not yet shipped:
 
----
+- One-line onboarding (no Docker, no LLM API key, no configuration).
+- Deliverable templates that produce ready-to-use Markdown documents.
+- Chinese IM sources beyond WeChat and QQ (飞书, 钉钉).
+- Local document source (.md / .pdf / .docx / .txt).
+- Embedded backend mode for users who want to try one source without
+  Docker.
+- MCP server entry point for direct agent integration.
+- Pluggable backend (currently locked to Hindsight FastAPI).
 
-## v0.1.x — close out stable (1–2 weeks)
+## v0.1.x — close out to stable
 
-- [x] CLI dispatcher (`memexa init / version / config / doctor / query`)
-- [x] PII scrubbing pre-commit hook
-- [x] Demo dataset (6 sources, public-domain)
-- [x] Direct psycopg2 PG access (no ssh shell-out by default)
-- [x] Hindsight failover URL with automatic retry
-- [x] 14 query subcommands documented
-- [x] `memexa doctor` round-trips LLM provider
-- [x] PII residual scanner with self-referential SKIP-list
-- [x] **CodeQL: 7 open errors → 0** (PR #12, 2026-05-15)
-- [x] **Dependabot vulnerability alerts ENABLED + automated security fixes ENABLED**
-- [x] **Fresh-clone smoke test passes on Win + macOS + Linux × Python 3.10/3.11/3.12 in CI** (verified by PR #12, 18/18 green)
-- [ ] CHANGELOG `known-limitation` line about PyPI availability — update to reflect LIVE on PyPI
-- [ ] Cut v0.1.0 stable after ≥ 1 week without a critical bug and ≥ 1 non-author issue / discussion
+The remaining v0.1 work unblocks the first-experience path for both
+**human users** and **AI agents**. v0.1.0 is cut from a green rc only
+after every item in this list is true.
 
-## v0.2 — three universal deliverable templates (4–8 weeks)
+- `memexa demo` subcommand: a thirty-second walkthrough that uses the
+  bundled synthetic dataset and the stub extractor. No Docker, no LLM
+  key, no configuration.
+- `--json` output mode for all fourteen query subcommands, so agents
+  invoking memexa via shell can `json.loads()` the result directly
+  instead of parsing text. The subprocess-CLI path is the current
+  first-class agent integration; native MCP server arrives in v0.5.
+- `Makefile` lint and format targets point at `memexa tests` rather
+  than the deprecated `src` path.
+- `CHANGELOG.md` known-limitation about PyPI availability removed
+  (the package has been on PyPI since rc1).
+- At least one non-author issue, discussion, or pull request landed.
+- At least one full week elapsed since the most recent critical bug
+  fix.
 
-The core query system gives you raw signals. v0.2 stitches them into
-copy-paste-ready documents. We ship **three** templates that cover all
-five user scenarios — not five separate templates. Each template = one
-subcommand + a Markdown layout + a couple of `memory_query` calls.
+## v0.2 — agent workflow templates
 
-- [ ] `memexa weekly` — cross-source weekly report
-  (git log + email + IM digest + project pulse → one-page Markdown)
-- [ ] `memexa brief <person|topic>` — pre-meeting / pre-talk / pre-call brief
-  (baseline / last interaction / open threads / landmines)
-- [ ] `memexa retro <window>` — time-window recap
-  (key events / commitments closed / commitments outstanding / surprises)
-- [ ] Template engine: shared Markdown layout + LLM provider abstraction
-  so v0.7 user-authored templates plug into the same pipeline
-- [ ] Three reproducible walkthroughs under `examples/deliverables/` —
-  one per user scenario (knowledge worker / researcher / freelancer)
+memexa is an **agent backbone**, not an end-user product. The typical
+flow is: human → Claude Code / Cursor / Cline → subprocess CLI to
+memexa → composed Markdown answer. v0.2 ships three workflow **spec
+documents** that tell the agent how to orchestrate the fourteen
+subcommands for the most common deliverables — **no new Python code,
+no new CLI subcommands**.
 
-**Cut from earlier draft** (deferred or absorbed into the three above):
-`lab-report` / `action-card` / `dashboard` — too narrow for general
-Chinese-market reach; `retro` covers the underlying pattern.
+- `docs/templates/weekly.md` — cross-source weekly report workflow.
+- `docs/templates/brief.md` — pre-meeting / pre-talk brief workflow.
+- `docs/templates/retro.md` — time-window recap workflow.
+- `docs/templates/README.md` — spec system overview and customisation
+  guide (users add their own templates by copying a spec file, no
+  code; the v0.7 milestone formalises the submission path).
+- One case study walking Claude Code through the weekly workflow on
+  the bundled demo dataset, so newcomers can see the agent + memexa
+  interaction concretely.
 
-## v0.3 — Chinese IM + identity deepening (reflow JARVIS, 4–6 weeks)
+v0.2 ships when the weekly spec lands on main and one walkthrough
+demonstrates a real Claude Code session producing a citation-bearing
+report.
 
-JARVIS upstream has these LIVE for months; the OSS migration is the next
-push. Each item links to the JARVIS HANDOFF entry that proves the
-capability is production-tested.
+## v0.3 — Chinese IM and identity deepening
 
-- [ ] **QQ db-only adapter** — port `jarvis/qq_db.py` (762 lines, stdlib
-      only) → `memexa/extraction/qq/qq_db.py`; rip the OSS-side NapCat
-      adapter
-      _([JARVIS §C.-24 LIVE 2026-05-15](https://github.com/labazhou2024/memexa))_
-- [ ] **doc source = 7th source** — local document graph integration
-      (.md / .pdf / .docx / .txt), file_sha1-bound not path-bound, so
-      moves and renames don't trigger re-extraction
-      _([JARVIS §C.-22 → §C.-26 buildup, v0.5 LIVE 2026-05-15](https://github.com/labazhou2024/memexa))_
-- [ ] **Identity manifest auto-learning** — cross-alias entity
-      resolution (`@张三` / `张老师` / `zhangsan@example.com` →
-      one canonical id), zero-LLM 4-phase algorithm
-      _(USAGE_MANUAL §19 in JARVIS, LIVE 2026-05-10)_
-- [ ] **WeChat PC backup ingestion** — beyond live MicroMsg.db,
-      support PC WeChat backup directory (so users on locked-down
-      devices can still ingest)
-- [ ] **飞书 (Lark) export** — adapter for the JSON export Lark
-      provides for personal accounts
-- [ ] **钉钉 (DingTalk) export** — adapter for the chat export
-- [ ] **Cut from earlier draft**: Discord / Slack / Telegram / iMessage
-      — OpenHuman owns the Western-SaaS lane via Composio OAuth; not
-      our market
+Capabilities proven LIVE in upstream development for ≥ 4 weeks
+without rollback reflow to memexa here. Each item requires a
+PII / abstraction audit before merge.
 
-## v0.4 — Audio + voice-id (reflow JARVIS, 3–5 weeks)
+- QQ db-only adapter; replaces the OSS-side NapCat path, which is
+  removed.
+- Local document source (.md / .pdf / .docx / .txt with file-sha1
+  binding so moves and renames do not trigger re-extraction).
+- Identity manifest auto-learning for cross-alias entity resolution.
+- WeChat PC backup ingestion.
+- 飞书 (Lark) export adapter.
+- 钉钉 (DingTalk) export adapter.
+- Embedded backend mode (`memexa backend --embedded`): sqlite-vss
+  alternative to docker-compose for users who only need one source.
 
-- [ ] **SenseVoice ASR reflow** — JARVIS audio v2 ships SenseVoice
-      replacing Whisper: 6.8% CER (vs Whisper ~10%), 5× realtime,
-      eliminated English-hallucination on Chinese audio
-      _([JARVIS §C.-23/-28 LIVE 2026-05-15/16](https://github.com/labazhou2024/memexa))_
-- [ ] **Cross-session voice manifest** — ECAPA embedding cross-session
-      voting + enroll-user-voice workflow; identify "self" vs "speaker
-      N" across recordings
-- [ ] **Multi-device audio merge** — recording pen (USB-MSC) + iPhone
-      voice memos + classroom dictation, dedup by content fingerprint
-- [ ] `memexa 会议纪要 <session>` — auto extract action items + key
-      decisions from a meeting recording (combines audio source +
-      `brief` template from v0.2)
+## v0.4 — audio and voice
 
-## v0.5 — AI agent integration as first-class (3–4 weeks)
+- SenseVoice ASR (Chinese CER ~6.8 %, replaces Whisper).
+- Cross-session voice manifest (ECAPA-based speaker enrollment).
+- Multi-device audio merge (recording-pen, iPhone Voice Memos,
+  classroom dictation).
+- `memexa 会议纪要 <session>`: meeting summary deliverable.
 
-- [ ] **`memexa-mcp` MCP server entry-point** — official Model Context
-      Protocol server so Claude Code / Cursor / Cline / any MCP-compatible
-      agent reads memexa as a memory backend
-- [ ] **Official `.mcp.json` template** in `examples/agent_integrations/`
-- [ ] **Cursor / Cline integration docs** — step-by-step
-- [ ] **`docs/for_agents.md` v2** — covering MCP spec, function-call
-      protocols, agent skill spec
-- [ ] **Cron + dashboard reflow** — Win schtask + Mac LaunchAgent +
-      Linux systemd templates for the 6-hour incremental cron, plus
-      the sys_monitor dashboard (port 8765, 7 panels)
-      _([JARVIS HANDOFF §E LIVE; Mac failover wrappers §C.-29 LIVE 2026-05-15](https://github.com/labazhou2024/memexa))_
+## v0.5 — AI agent integration completion
 
-## v0.6 — Pluggable LLM + pluggable backend (4–6 weeks)
+The `subprocess` CLI path is the v0.1.x first-class agent integration.
+v0.5 promotes that to a native MCP integration so agents can invoke
+memexa as a structured tool without spawning a shell.
 
-The key strategic move: **memexa stops competing with mem0 / MemPalace
-on backend; we federate to them as user choice.**
+- `memexa-mcp`: Model Context Protocol server entry point exposing all
+  fourteen query subcommands and the v0.2 workflow specs as MCP tools.
+- Official Claude Code, Cursor, and Cline integration examples under
+  `examples/agent_integrations/` with a one-line `.mcp.json` snippet.
+- `docs/for_agents.md` updated to v2 covering MCP spec, function-call
+  protocol, and agent skill specification.
 
-- [ ] **LLM provider abstraction** — adapters for OpenAI / DeepSeek /
-      Qwen3 / vLLM / Ollama / LiteLLM proxy / OpenRouter / 自部署
-      OpenAI-compatible endpoint
-- [ ] **Backend adapter** — `memexa --backend=chroma|mem0|mempalace|hindsight`
-      switches the storage layer without changing the query / deliverable layer
-- [ ] **Schema drift sanitize reflow** — JARVIS §C.-29 §10 ships
-      `_normalize_llm_card` covering 5 new drift classes (date-only ISO,
-      time-only ISO, role=relay, related_episode dict, when_end None);
-      port to OSS so extractor model swaps don't break PG inserts
-- [ ] **5-driver rc=2 graceful-skip pattern** — reflow JARVIS
-      [§C.-29 §2 LIVE 2026-05-15](https://github.com/labazhou2024/memexa);
-      transient backend outage no longer poisons cron
+## v0.6 — pluggable LLM and pluggable backend
 
-## v0.7 — User-authored deliverable templates (4 weeks)
+memexa stops competing with adjacent backends and federates to them
+as a user choice.
 
-The deliverable layer becomes an ecosystem, not a fixed list of three.
+- LLM provider abstraction: adapters for OpenAI, DeepSeek, Qwen,
+  vLLM, Ollama, LiteLLM, OpenRouter, and self-hosted OpenAI-compatible
+  endpoints.
+- Backend adapter: `memexa --backend=chroma|mem0|mempalace|hindsight`
+  switches the storage layer without changing the query or deliverable
+  layer.
+- Schema-drift sanitizer so extractor model swaps do not break
+  database inserts.
 
-- [ ] **Template authoring spec** — `~/.memexa/templates/<name>.yaml`
-      with declared inputs (which subcmds to call), Markdown / LaTeX
-      layout, and optional LLM-rendering step
-- [ ] **Six example user-authored templates** (one per scenario type):
-      - 客户跟进 (small-business)
-      - 学习笔记 (researcher / student)
-      - 阅读简报 (knowledge worker)
-      - 创作素材库 (content creator)
-      - 每日复盘 (GTD / self-quantified)
-      - 答辩 brief (researcher / student)
-- [ ] **Template submission contrib path** — community templates land
-      in `examples/community_templates/` via PR, not built-in
+## v0.7 — user-authored workflow spec templates
 
-## v1.0 — stable schema commitment + ecosystem (≥ 6 months out)
+The workflow-template layer becomes an ecosystem rather than a fixed
+list of three. Users author their own spec documents the same way the
+v0.2 specs are written — Markdown that the agent reads at runtime.
 
-- [ ] V2 envelope frozen; migrations only via additive fields
-- [ ] CLI args frozen; deprecations only with one-release warning
-- [ ] On-disk layout frozen; bumping bumps a major version
-- [ ] Backend adapter interface frozen
-- [ ] ≥ 4 deliverable templates LIVE (3 builtin + ≥ 1 community)
-- [ ] ≥ 4 Chinese-IM sources LIVE (WeChat / QQ / 飞书 / 钉钉)
-- [ ] ≥ 3 external contributors with merged PRs
-- [ ] ≥ 5 real production users (non-author) documented in
-      `docs/case_studies/` or `examples/community_templates/`
+- Spec loading mechanism: memexa discovers user spec files under
+  `~/.memexa/templates/` in addition to the bundled
+  `docs/templates/`. Agents see the combined list as available tools.
+- Six example community spec templates under
+  `examples/community_templates/` covering distinct user scenarios
+  (client follow-up, study notes, reading brief, content backlog,
+  daily retro, defense brief).
+- Spec submission path via pull request into
+  `examples/community_templates/`.
 
-## Permanently out of scope (expanded 2026-05-16)
+No new Python code is required to add a template; v0.7 is documented
+schema + a submission path.
 
-- ❌ **Desktop GUI** — OpenHuman owns this lane via Tauri + 118 OAuth
-- ❌ **Western-SaaS OAuth bulk** — Gmail / Slack / Notion / Linear /
-      Jira via Composio is OpenHuman's moat; we do not chase
-- ❌ **Mobile / web UI rewrites**
-- ❌ **Multi-tenant hosted service**
-- ❌ **Voice synthesis or agent loops** — distinct project category
-- ❌ **English single-thread benchmark race** (LongMemEval / LoCoMo /
-      MemBench on English ChatGPT-style threads) — MemPalace owns these.
-      memexa **will** publish its own benchmark, but on Chinese-native
-      multi-party data: group-chat speaker disambiguation, cross-alias
-      entity resolution accuracy, relative-time anchor correctness,
-      and `evidence_quotes` citation-back-to-source-sentence precision.
-      Target: ship `benchmarks/cn_multiparty/` in v0.3 with 5 reproducible
-      Chinese WeChat / QQ scenarios.
-- ❌ **Anything that prevents you from owning your own data**
+## v0.8+ — desktop GUI (optional, condition-gated)
 
-## How to propose a roadmap change
+Desktop GUI is acknowledged as a real driver of broader audience reach
+but it is not on the critical path. memexa is agent-backbone first;
+a desktop shell is layered on top only when the foundation is solid.
 
-Open a Discussion in the **Ideas** category with:
+Conditions for opening a v0.8 GUI exploration:
 
-- What you would add / drop.
-- Which milestone it fits.
-- Whether you are volunteering to implement it.
-- Which user scenario it serves (knowledge worker / researcher /
-  creator / small-business / self-quantified — or a new one).
+- v0.5 MCP integration shipped and at least one well-known AI agent
+  (Claude Code / Cursor / Cline) has the memexa server snippet pinned
+  in their community docs.
+- v0.7 community templates ≥ 5 merged.
+- Roughly 3 000 GitHub stars and 5 000 PyPI monthly downloads.
 
-The BDFL will respond yes / no / later, with a one-paragraph reason.
+If those conditions hold, an evaluation PR opens to pick one of:
 
----
+- (a) Tauri shell wrapping the CLI as backend.
+- (b) Streamlit local web UI.
+- (c) Stay terminal + agent only.
 
-## Parallel-execution task plan (for fast iteration with multiple contributors)
+This milestone is explicitly **not** committed work; the project may
+remain terminal-only forever and still meet its goals.
 
-Multiple contributors can work in parallel on independent task units.
-Each unit = one feature branch + one PR + isolated test scope. Below
-is the v0.2 / v0.3 / v0.4 task split designed so 3–5 contributors can
-work concurrently without merge conflicts.
+## v1.0 — stable schema commitment
 
-### v0.2 — three deliverable templates (3 parallel tracks)
+- V2 envelope frozen; migrations only via additive fields.
+- CLI arguments frozen; deprecations only with one-release warning.
+- On-disk layout frozen; bumping bumps a major version.
+- Backend adapter interface frozen.
+- At least three external contributors with merged pull requests.
+- At least five non-author production users documented in case
+  studies or community templates.
 
-| Track | Owner | Branch | Files touched (isolated) |
-|---|---|---|---|
-| **A. `memexa weekly`** | contributor #1 | `feat/v0.2-weekly-template` | `memexa/deliverables/weekly.py` (new) + `tests/integration/test_weekly_deliverable.py` (new) + `examples/deliverables/01_weekly_knowledge_worker.md` (new) |
-| **B. `memexa brief <person\|topic>`** | contributor #2 | `feat/v0.2-brief-template` | `memexa/deliverables/brief.py` (new) + `tests/...test_brief_deliverable.py` (new) + `examples/deliverables/02_brief_researcher.md` (new) |
-| **C. `memexa retro <window>`** | contributor #3 | `feat/v0.2-retro-template` | `memexa/deliverables/retro.py` (new) + `tests/...test_retro_deliverable.py` (new) + `examples/deliverables/03_retro_freelancer.md` (new) |
-| **D. Shared template engine** | maintainer | `feat/v0.2-template-engine` | `memexa/deliverables/__init__.py` (new) + `memexa/deliverables/_base.py` (new) + `memexa/deliverables/_provider.py` (LLM provider abstraction) — **lands first, A/B/C depend on this** |
-| **E. CLI dispatch + docs** | maintainer | `feat/v0.2-cli-routes` | `memexa/cli/main.py` (add `weekly`/`brief`/`retro` subcmds) + `docs/usage_guide.md` + `docs/usage_guide.zh.md` |
+## Permanently out of scope
 
-### v0.3 — Chinese IM + identity reflow (5 parallel tracks)
+- Desktop GUI applications.
+- Bulk Western-SaaS OAuth integrations (Gmail, Slack, Notion, Linear,
+  Jira via Composio-style gateways).
+- Mobile or web UI rewrites.
+- Multi-tenant hosted service.
+- Voice synthesis or autonomous agent loops.
+- Anything that prevents users from owning their own data.
 
-| Track | Owner | Branch | Status |
-|---|---|---|---|
-| **F. QQ db-only adapter** | contributor / maintainer | `feat/v0.3-qq-db-only` | reflow `jarvis/qq_db.py` 762 lines from upstream JARVIS |
-| **G. doc source = 7th** | contributor / maintainer | `feat/v0.3-doc-source` | reflow JARVIS doc-source v0.5 LIVE 2026-05-15 |
-| **H. identity manifest** | contributor / maintainer | `feat/v0.3-identity-manifest` | reflow JARVIS USAGE_MANUAL §19 |
-| **I. 飞书 (Lark) export adapter** | contributor | `feat/v0.3-lark-adapter` | new from scratch (no upstream parallel) |
-| **J. 钉钉 (DingTalk) export adapter** | contributor | `feat/v0.3-dingtalk-adapter` | new from scratch |
-| **K. benchmarks/cn_multiparty/** | maintainer | `feat/v0.3-cn-benchmark-suite` | new — 5 reproducible WeChat / QQ scenarios |
+## How to propose a change
 
-### v0.4 — audio + voice (3 parallel tracks)
-
-| Track | Owner | Branch |
-|---|---|---|
-| **L. SenseVoice ASR reflow** | contributor | `feat/v0.4-sensevoice-asr` |
-| **M. Cross-session voice manifest** | contributor | `feat/v0.4-voice-manifest` |
-| **N. `memexa 会议纪要 <session>`** | contributor | `feat/v0.4-meeting-summary` |
-
-### Contributor onboarding
-
-When ≥1 contributor is on-board, the maintainer opens a "v0.X
-coordination" Discussion thread per release; tracks A–N above are
-filed as separate issues with `good-first-issue` or `help-wanted`
-labels. Each track has its own `tests/...` scope so parallel PRs do
-not collide.
-
----
-
-## Reflow status from upstream JARVIS (LIVE capability inventory)
-
-| JARVIS LIVE capability | OSS reflow target | Status |
-|---|---|---|
-| 6 sources (WeChat / QQ / Email / Browser / Claude Code / Audio) | v0.1 | ✅ shipped |
-| 14 query subcommands (basic 9 + advanced 5) | v0.1 | ✅ shipped |
-| Streaming POST + verify + dead-letter retry | v0.1 | ✅ shipped |
-| Doc source (file_sha1-bound, .md/.pdf/.docx/.txt) | **v0.3** | reflow pending |
-| QQ db-only (NapCat → SQLCipher direct) | **v0.3** | reflow pending |
-| Identity manifest cross-alias resolution | **v0.3** | reflow pending |
-| SenseVoice ASR + voice enroll | **v0.4** | reflow pending |
-| MCP server entry-point | **v0.5** | new in OSS |
-| Schema drift sanitize (5 classes) | **v0.6** | reflow pending |
-| 5-driver rc=2 graceful-skip pattern | **v0.6** | reflow pending |
-| Mac failover wrappers (PG stale-lock + hindsight pg_isready) | docs in v0.5 | reflow pending |
-| Win cron + Mac LaunchAgent + sys_monitor dashboard | **v0.5** | reflow pending |
-
-JARVIS upstream remains the experimental edge; OSS reflow happens after
-a capability runs ≥ 4 weeks LIVE in JARVIS without rollback. This keeps
-OSS users on capabilities that survived real production load.
+Open a Discussion in the **Ideas** category with what to add or drop,
+which milestone it fits, and whether you can implement it. The
+maintainer responds yes / no / later with a paragraph of reasoning.

--- a/ROADMAP.zh.md
+++ b/ROADMAP.zh.md
@@ -4,261 +4,180 @@
 
 > 期望式表达。不是承诺。该动的时候才动。
 
-## 定位 (2026-05-16 修订)
+## 定位
 
-**项目目标**: 成为**国内中文原生多人数据 memory-graph OSS 第一**。
+memexa 是面向中文原生多人数据的自托管 memory graph — 微信 / QQ /
+飞书 / 钉钉 群聊、中文邮件长链、中文音频录音。每条消息按 verbatim
+存储, 再由双 LLM 抽取流程产出结构化 envelope（narrative + entities
++ 每条断言对应的 evidence_quotes + time_resolutions +
+relation_assertions）。查询跨 source, 返回带 citation 的 cards, 进入
+deliverable 模板生成可直接交付的文档。
 
-memexa 面向**整个中文市场**，不限定单一群体。**两条复合护城河**：
+memexa 占据相邻 OSS 项目未覆盖的赛道: 中文原生数据源、高准确度
+回溯到原句的 citation、面向人和 AI agent 双使用的 CLI 优先设计。
 
-1. **中文原生数据源**: 微信 / QQ / 飞书 / 钉钉 多人群聊、中文音频、
-   中文邮件长链 — OpenHuman / MemPalace 的西方 SaaS OAuth + 摘要 /
-   verbatim 模型处理不好这些。
-2. **V2 envelope 抽取 + 每条断言原文引用**: verbatim 原始 + LLM
-   抽取 narrative + `evidence_quotes` + `identity_assertions` +
-   `time_resolutions` + `relation_assertions`。层级摘要（OpenHuman）
-   必然丢信息；字面 Zettelkasten（MemPalace）无法在群聊里区分"谁
-   对谁说"。memexa 两层兼得 + 每条 claim 绑回原句。
+关于与相邻项目（OpenHuman、MemPalace、ReMe）的逐项能力对比, 以及
+memexa 服务的 5 类用户场景, 见 [docs/why.zh.md](docs/why.zh.md)。
 
-相邻 OSS（OpenHuman、MemPalace、ReMe）覆盖英文 / Western-SaaS /
-desktop-assistant / dev-tool-MCP 赛道。memexa 主动留在中文原生 +
-高准确度 citation 赛道。
+## 当前状态 (v0.1.0-rc2 已在 PyPI, 2026-05-16)
 
-**memexa 服务的 5 类用户场景：**
+已 ship:
 
-| 场景 | 典型用户 | 主用 deliverable |
-|---|---|---|
-| 知识工作者 / PM / 咨询 | 双语办公人士、自由职业 | `weekly` (跨源周报), `brief <人>` (会前 brief) |
-| 研究者 / 学生 / 学者 | 在校生、研究生 | `brief <主题>` (答辩 / talk 准备), `retro <时段>` (项目复盘) |
-| 内容创作者 / 自媒体 | 公众号作者、知乎答主、小红书博主 | `retro <时段>` (灵感回收), v0.7 自定义 `notebook` 类模板 |
-| 中小企业主 / 个体户 | 自由专业人士、小工作室主 | `brief <人>` (客户 / 潜客准备), `retro <时段>` (交易复盘) |
-| 自我量化 / GTD / 隐私用户 | self-hosted 极客、GTD 实践者 | `pending` (跨源待办), `retro <时段>` (周回顾) |
+- CLI: `init` / `version` / `config` / `doctor` / `query`
+- 14 个查询子命令 (基础 9 + 高级 5)
+- 6 个摄入源: 微信、QQ、邮件、浏览、Claude Code、音频
+- 双 LLM gate-extract 流程, DeepSeek arbiter 仲裁
+- PostgreSQL + pgvector 后端 (docker compose 内含 Hindsight FastAPI)
+- 端口 8765 dashboard, 7 个 panel
+- macOS / Windows / Linux + Docker 三平台部署指南
+- 8 个测试, 19 个 CI workflow 检查, CodeQL 0 open error
+- Dependabot 漏洞 alerts 已启用, 自动安全修复已启用
+- Fresh-clone smoke test 在 Win + macOS + Linux × Python 3.10 / 3.11 / 3.12 通过
 
-5 个场景共用同一套底层（ingestion + 抽取 + 图谱 + 查询 + 交付模板）。
-模板有差异；v0.2 ship 3 个最广义的（`weekly` / `brief` / `retro`），
-v0.7 让用户自定义自己的模板。
+未 ship:
 
----
+- 一行命令 onboarding（无需 Docker, 无需 LLM API key, 无需配置）
+- 自动生成可直接交付的 Markdown 文档的 deliverable 模板
+- 微信 + QQ 以外的中文 IM 源（飞书 / 钉钉）
+- 本地文档源 (.md / .pdf / .docx / .txt)
+- 让用户不装 Docker 也能试用 1 个 source 的 embedded backend mode
+- 直接 agent 接入的 MCP server entry point
+- 可插拔后端（当前锁在 Hindsight FastAPI）
 
-## v0.1.x — 收尾 stable (1-2 周)
+## v0.1.x — 收尾 stable
 
-- [x] CLI dispatcher (`memexa init / version / config / doctor / query`)
-- [x] PII 脱敏 pre-commit hook
-- [x] Demo 数据集 (6 source, 公有领域)
-- [x] 直接 psycopg2 PG 访问
-- [x] Hindsight failover URL 自动重试
-- [x] 14 个查询子命令文档化
-- [x] `memexa doctor` 端到端检 LLM provider
-- [x] PII 残留扫描器 + 自引用 SKIP-list
-- [x] **CodeQL: 7 个 open error → 0** (PR #12, 2026-05-15)
-- [x] **Dependabot 漏洞 alerts 已启用 + 自动安全修复已启用**
-- [x] **Fresh-clone smoke test 在 Win + macOS + Linux × Python 3.10/3.11/3.12 全 CI 通过** (PR #12 18/18 绿验证)
-- [ ] CHANGELOG 中 "PyPI 还没上" 这条 known-limitation 改成 LIVE on PyPI
-- [ ] ≥ 1 周无 critical bug + ≥ 1 个非作者 issue / discussion → 发 v0.1.0 stable
+剩下的 v0.1 工作 = 同时打通**人类用户**和 **AI agent** 的第一体验路径。
+v0.1.0 仅在以下所有条件全部为真时, 才从绿色 rc 中切版本。
 
-## v0.2 — 3 个通用 deliverable 模板 (4-8 周)
+- `memexa demo` 子命令: 30 秒 walkthrough, 用 bundled synthetic 数据
+  + stub extractor。无需 Docker, 无需 LLM key, 无需配置。
+- 14 个查询子命令全部加 `--json` 输出 mode, 让 agent 通过 shell 调
+  memexa 时能直接 `json.loads()`, 不用 parse 文本。subprocess CLI 路径
+  是当前 first-class agent integration; native MCP server 留 v0.5。
+- `Makefile` 的 lint / format target 指向 `memexa tests`（而不是已废
+  弃的 `src` 路径）。
+- `CHANGELOG.md` 删除"PyPI 尚未上"那条 known-limitation（rc1 起已 LIVE）。
+- 至少 1 个非作者的 issue / discussion / pull request 已 land。
+- 自最近一个 critical bug fix 起至少经过 1 周。
 
-核心查询系统给原始信号。v0.2 把它们缝成可复制粘贴的文档。覆盖 5 个用户
-场景的**3 个最广义模板**（不是 5 个独立模板）。每个模板 = 一个子命令
-+ Markdown 布局 + 几个 `memory_query` 调用。
+## v0.2 — agent workflow 模板 (spec 文档, 非 Python 代码)
 
-- [ ] `memexa weekly` — 跨源周报
-  (git log + 邮件 + IM 摘要 + 项目脉搏 → 一页 Markdown)
-- [ ] `memexa brief <人 | 主题>` — 见面 / 演讲 / 客户来电前 brief
-  (基线 / 上次互动 / 未结清话题 / 雷区)
-- [ ] `memexa retro <时段>` — 时段复盘
-  (重要事件 / 已闭环承诺 / 未闭环承诺 / 意外)
-- [ ] 模板引擎：共享 Markdown 布局 + LLM provider 抽象层
-  (这样 v0.7 用户自定义模板能直接插入同一管道)
-- [ ] 3 篇可复现 walkthrough 落在 `examples/deliverables/` —
-  每个用户场景一篇（知识工作者 / 研究者 / 自由职业）
+memexa 是 **agent backbone**, 不是 end-user product。典型流: 人 →
+Claude Code / Cursor / Cline → subprocess CLI 调 memexa → 合成
+Markdown 答案。v0.2 ship 3 份 workflow **spec 文档** 告诉 agent 如何
+组合 14 个 subcmd 产出常见 deliverable —— **不写任何 Python 代码,
+不加任何 CLI 子命令**。
 
-**从早期草案砍掉**: `lab-report` / `action-card` / `dashboard`
-（学生场景太窄，被 `retro` 模板的通用 pattern 吸收）
+- `docs/templates/weekly.md` — 跨源周报 workflow。
+- `docs/templates/brief.md` — 见面 / 演讲前 brief workflow。
+- `docs/templates/retro.md` — 时段复盘 workflow。
+- `docs/templates/README.md` — spec 系统总览 + 用户自定义指南
+  (加自己的模板 = 复制 spec 文件, 零代码; v0.7 正式开通提交通道)。
+- 1 篇 case study 走查 Claude Code 在 demo dataset 上跑完整 weekly
+  流程, 让新访客**看见**"agent + memexa 实际怎么交互"。
 
-## v0.3 — 中文 IM + 身份解析深化 (反流 JARVIS, 4-6 周)
+v0.2 在 weekly spec land 到 main + 1 篇 walkthrough 演示真 Claude
+Code session 产出带 citation 周报 时 ship。
 
-JARVIS 上游已 LIVE 数月，OSS 反流是下一波推进重点。每项注明对应的
-JARVIS HANDOFF 节点，证明能力已经过生产验证。
+## v0.3 — 中文 IM 与身份解析深化
 
-- [ ] **QQ db-only 适配器** — 把 `jarvis/qq_db.py` (762 行, 仅标准库)
-      移植到 `memexa/extraction/qq/qq_db.py`；删 OSS 端 NapCat 适配器
-      _(JARVIS §C.-24 LIVE 2026-05-15)_
-- [ ] **doc source = 第 7 个 source** — 本地文档入图
-      (.md / .pdf / .docx / .txt), file_sha1 绑定不绑 path,
-      移动 / 重命名不触发重抽
-      _(JARVIS §C.-22 → §C.-26 buildup, v0.5 LIVE 2026-05-15)_
-- [ ] **Identity manifest 自学习** — 跨别名实体收敛
-      (`@张三` / `张老师` / `zhangsan@example.com` → 一个 canonical id),
-      4 阶段 0-LLM 算法
-      _(JARVIS USAGE_MANUAL §19, LIVE 2026-05-10)_
-- [ ] **微信 PC 备份摄入** — 不只 live MicroMsg.db，
-      支持 PC 微信备份目录 (被锁定设备的用户也能用)
-- [ ] **飞书 (Lark) export 适配器** — 个人账号 JSON 导出
-- [ ] **钉钉 (DingTalk) export 适配器** — 聊天导出
-- [ ] **从早期草案砍掉**: Discord / Slack / Telegram / iMessage —
-      OpenHuman 通过 Composio OAuth 占了 Western-SaaS 赛道，不是我们的市场
+在上游开发中 LIVE ≥ 4 周无回退的能力, 在此 milestone 反流到 memexa。
+每项需先做 PII / 抽象 audit 后才 merge。
 
-## v0.4 — 音频 + 声纹中文场景增强 (反流 JARVIS, 3-5 周)
+- QQ db-only 适配器; 替换并删除 OSS 端 NapCat 路径。
+- 本地文档源 (.md / .pdf / .docx / .txt, 用 file-sha1 绑定, 移动 /
+  重命名不触发重抽)。
+- Identity manifest 自学习, 跨别名实体收敛。
+- 微信 PC 备份摄入。
+- 飞书 (Lark) export 适配器。
+- 钉钉 (DingTalk) export 适配器。
+- Embedded backend mode (`memexa backend --embedded`): sqlite-vss 后端
+  替代 docker-compose, 给只想接 1 个 source 的用户。
 
-- [ ] **SenseVoice ASR 反流** — JARVIS audio v2 用 SenseVoice 替换
-      Whisper：中文 CER 6.8% (vs Whisper ~10%), 5× realtime,
-      消除中文音频英文 hallucination
-      _(JARVIS §C.-23/-28 LIVE 2026-05-15/16)_
-- [ ] **跨 session voice manifest** — ECAPA 嵌入跨 session 投票 +
-      enroll-user-voice 工作流; 跨录音识别"自己"vs "speaker N"
-- [ ] **多设备音频合并** — 录音笔 (USB-MSC) + iPhone 录音备忘 +
-      课堂 / 会议口录, 按内容指纹去重
-- [ ] `memexa 会议纪要 <session>` — 从录音自动抽行动项 + 关键决策
-      (结合 audio source + v0.2 的 `brief` 模板)
+## v0.4 — 音频与声纹
 
-## v0.5 — AI agent integration 升级到一级公民 (3-4 周)
+- SenseVoice ASR (中文 CER ~6.8 %, 替换 Whisper)。
+- 跨 session voice manifest, 基于 ECAPA 嵌入的说话人 enrollment。
+- 多设备音频合并 (录音笔、iPhone 录音备忘、课堂口录)。
+- `memexa 会议纪要 <session>`: 会议纪要 deliverable。
 
-- [ ] **`memexa-mcp` MCP server entry-point** — 官方 Model Context
-      Protocol server, 让 Claude Code / Cursor / Cline / 任何 MCP 兼容
-      agent 把 memexa 当 memory backend 调
-- [ ] **官方 `.mcp.json` 模板** 落在 `examples/agent_integrations/`
-- [ ] **Cursor / Cline integration docs** — 一步步教
-- [ ] **`docs/for_agents.md` v2** — 覆盖 MCP spec / function-call 协议 /
-      agent skill spec
-- [ ] **Cron + dashboard 反流** — Win schtask + Mac LaunchAgent +
-      Linux systemd 模板, 6 小时增量 cron, sys_monitor dashboard
-      (端口 8765, 7 个面板)
-      _(JARVIS HANDOFF §E LIVE; Mac failover wrappers §C.-29 LIVE 2026-05-15)_
+## v0.5 — AI agent integration 完整化
 
-## v0.6 — Pluggable LLM + Pluggable Backend (4-6 周)
+subprocess CLI 路径是 v0.1.x 的 first-class agent integration。v0.5
+把它升级为 native MCP integration, 让 agent 不用 spawn shell 即可把
+memexa 当结构化工具调。
 
-关键战略动作: **memexa 停止在 backend 层与 mem0 / MemPalace 竞争,
-我们 federate 到它们作为用户选项。**
+- `memexa-mcp`: Model Context Protocol server entry point, 把 14 个查
+  询子命令和 v0.2 的 workflow spec 一并暴露为 MCP tools。
+- Claude Code / Cursor / Cline 官方 integration 示例落在
+  `examples/agent_integrations/`, 含一行 `.mcp.json` snippet。
+- `docs/for_agents.md` 升级到 v2, 覆盖 MCP spec / function-call 协议 /
+  agent skill specification。
 
-- [ ] **LLM provider 抽象** — 适配 OpenAI / DeepSeek / Qwen3 / vLLM /
-      Ollama / LiteLLM proxy / OpenRouter / 自部署 OpenAI 兼容 endpoint
-- [ ] **Backend adapter** — `memexa --backend=chroma|mem0|mempalace|hindsight`
-      切换底层存储, 不动 query / deliverable 层
-- [ ] **Schema drift sanitize 反流** — JARVIS §C.-29 §10 的
-      `_normalize_llm_card` 覆盖 5 类新 drift (date-only ISO / time-only ISO
-      / role=relay / related_episode dict / when_end None);
-      反流让 OSS 切换 extractor 模型时不破 PG insert
-- [ ] **5 driver rc=2 graceful-skip 模式反流** — JARVIS §C.-29 §2
-      LIVE 2026-05-15; backend 临时不可达不再污染 cron
+## v0.6 — 可插拔 LLM 与可插拔后端
 
-## v0.7 — 用户自定义 deliverable 模板 (4 周)
+memexa 停止在 backend 层与相邻项目竞争, federate 到它们作为用户选项。
 
-交付层升级为生态, 不再是固定 3 个。
+- LLM provider 抽象: OpenAI / DeepSeek / Qwen / vLLM / Ollama /
+  LiteLLM / OpenRouter / 自部署 OpenAI 兼容 endpoint 适配。
+- 后端适配器: `memexa --backend=chroma|mem0|mempalace|hindsight`
+  切换底层存储, 不动 query / deliverable 层。
+- Schema drift sanitizer, 让 extractor 模型切换不破 DB insert。
 
-- [ ] **模板创作 spec** — `~/.memexa/templates/<name>.yaml`
-      声明输入 (调哪些 subcmd) / Markdown / LaTeX 布局 / 可选 LLM 渲染步
-- [ ] **6 个示例用户自定义模板** (每个场景一个):
-      - 客户跟进 (中小企业主)
-      - 学习笔记 (研究者 / 学生)
-      - 阅读简报 (知识工作者)
-      - 创作素材库 (内容创作者)
-      - 每日复盘 (GTD / 自我量化)
-      - 答辩 brief (研究者 / 学生)
-- [ ] **模板提交 contrib 通道** — 社区模板通过 PR 进
-      `examples/community_templates/`, 不内置
+## v0.7 — 用户自定义 workflow spec 模板
 
-## v1.0 — schema 稳定承诺 + 生态形成 (≥ 6 个月之后)
+workflow 模板层变生态, 不再是固定 3 个。用户写自己的 spec 文档跟
+v0.2 内置 spec 同一种格式 —— agent 在运行时读 Markdown。
 
-- [ ] V2 envelope 冻结; 迁移只能加 field
-- [ ] CLI 参数冻结; 弃用前提前一版警告
-- [ ] On-disk 布局冻结; 改动 = bump major version
-- [ ] Backend adapter 接口冻结
-- [ ] ≥ 4 个交付模板 LIVE (3 内建 + ≥ 1 社区)
-- [ ] ≥ 4 个中文 IM source LIVE (微信 / QQ / 飞书 / 钉钉)
-- [ ] ≥ 3 个外部 contributor merge PR
-- [ ] ≥ 5 个真实生产用户 (非作者) 在 `docs/case_studies/` 或
-      `examples/community_templates/` 留下案例
+- spec 加载机制: memexa 发现 `~/.memexa/templates/` 下的用户 spec 文件
+  + bundled `docs/templates/`, agent 看到合并后的可用工具列表。
+- 6 个示例社区 spec 模板落在 `examples/community_templates/`, 每个覆盖
+  一类独立用户场景 (客户跟进 / 学习笔记 / 阅读简报 / 创作素材库 /
+  每日复盘 / 答辩 brief)。
+- spec 通过 pull request 提交进 `examples/community_templates/`。
 
-## 永久不做 (2026-05-16 扩充)
+加新模板**不需要写 Python 代码**; v0.7 = 文档化 schema + 提交通道。
 
-- ❌ **Desktop GUI** — OpenHuman 通过 Tauri + 118 OAuth 已占
-- ❌ **泛 Western-SaaS OAuth** — Gmail / Slack / Notion / Linear /
-      Jira 通过 Composio = OpenHuman 护城河, 不追
-- ❌ **Mobile / web UI 重写**
-- ❌ **多租户 hosted service**
-- ❌ **语音合成 / agent loop** — 不同项目类别
-- ❌ **英文单线 benchmark 战** (LongMemEval / LoCoMo / MemBench
-      在英文 ChatGPT-style 单线对话上) — MemPalace 占。memexa **会**
-      发自己的 benchmark, 但在中文原生多人数据上: 群聊说话者
-      消歧 / 跨别名实体收敛精度 / 相对时间锚点正确性 /
-      `evidence_quotes` 回溯原句精度。目标: v0.3 落
-      `benchmarks/cn_multiparty/` 含 5 个可复现的中文微信 / QQ 场景
-- ❌ **任何阻止你拥有自己数据的设计**
+## v0.8+ — desktop GUI (可选, 条件锚)
 
-## 提议路线图改动
+桌面 GUI 公认能扩大受众, 但**不在关键路径**。memexa 是 agent backbone
+优先, 桌面 shell 只在底座稳后再叠。
 
-在 **Ideas** 类别开个 Discussion, 写:
+开 v0.8 GUI 评估的条件:
 
-- 加什么 / 砍什么
-- 落哪个 milestone
-- 你是否愿意实现
-- 服务哪个用户场景 (知识工作者 / 研究者 / 创作者 / 中小企业主 /
-  自我量化 — 或新场景)
+- v0.5 MCP integration 已 ship, 至少 1 个知名 AI agent (Claude Code /
+  Cursor / Cline) 社区文档 pin 了 memexa server 配置 snippet。
+- v0.7 社区 spec 模板 ≥ 5 个 merged。
+- 约 3 000 GitHub stars + 5 000 PyPI 月下载。
 
-BDFL 会一段话回 yes / no / later。
+条件满足后, 开评估 PR 选其一:
 
----
+- (a) Tauri shell 包装 CLI 作 backend。
+- (b) Streamlit 本地 web UI。
+- (c) 保持终端 + agent only。
 
-## 并行执行任务划分 (快速迭代 / 多 contributor 协作)
+本 milestone **不**是承诺工作; 项目可永久 terminal-only 仍达目标。
 
-多个 contributor 可并行做独立 task。每个 unit = 1 个 feature branch +
-1 个 PR + 隔离的 test scope。下面是 v0.2 / v0.3 / v0.4 拆分，
-3-5 个 contributor 能同时推进不冲突。
+## v1.0 — schema 稳定承诺
 
-### v0.2 — 3 个交付模板 (3 条并行 track)
+- V2 envelope 冻结; 迁移只能加 field。
+- CLI 参数冻结; 弃用前提前一版警告。
+- On-disk layout 冻结; 改动 = bump major version。
+- 后端适配器接口冻结。
+- ≥ 3 个外部 contributor 有 merged pull request。
+- ≥ 5 个非作者生产用户在 case studies 或 community templates 中留下案例。
 
-| Track | Owner | Branch | 涉及文件 (隔离) |
-|---|---|---|---|
-| **A. `memexa weekly`** | contributor #1 | `feat/v0.2-weekly-template` | `memexa/deliverables/weekly.py` (新) + `tests/integration/test_weekly_deliverable.py` (新) + `examples/deliverables/01_weekly_knowledge_worker.md` (新) |
-| **B. `memexa brief <人\|主题>`** | contributor #2 | `feat/v0.2-brief-template` | `memexa/deliverables/brief.py` (新) + `tests/...test_brief_deliverable.py` (新) + `examples/deliverables/02_brief_researcher.md` (新) |
-| **C. `memexa retro <时段>`** | contributor #3 | `feat/v0.2-retro-template` | `memexa/deliverables/retro.py` (新) + `tests/...test_retro_deliverable.py` (新) + `examples/deliverables/03_retro_freelancer.md` (新) |
-| **D. 共享模板引擎** | 维护者 | `feat/v0.2-template-engine` | `memexa/deliverables/__init__.py` (新) + `memexa/deliverables/_base.py` (新) + `memexa/deliverables/_provider.py` (LLM provider 抽象) — **先 ship, A/B/C 依赖** |
-| **E. CLI 路由 + docs** | 维护者 | `feat/v0.2-cli-routes` | `memexa/cli/main.py` (加 `weekly`/`brief`/`retro` subcmd) + `docs/usage_guide.md` + `docs/usage_guide.zh.md` |
+## 永久不做
 
-### v0.3 — 中文 IM + identity 反流 (5 条并行 track)
+- Desktop GUI 应用。
+- 泛 Western-SaaS OAuth 集成 (Gmail / Slack / Notion / Linear /
+  Jira 通过 Composio 式 gateway)。
+- Mobile / web UI 重写。
+- 多租户 hosted service。
+- 语音合成或 autonomous agent loop。
+- 任何阻止用户拥有自己数据的设计。
 
-| Track | Owner | Branch | 状态 |
-|---|---|---|---|
-| **F. QQ db-only 适配器** | contributor / 维护者 | `feat/v0.3-qq-db-only` | 反流 JARVIS `jarvis/qq_db.py` 762 行 |
-| **G. doc source 第 7 个** | contributor / 维护者 | `feat/v0.3-doc-source` | 反流 JARVIS doc-source v0.5 LIVE 2026-05-15 |
-| **H. identity manifest** | contributor / 维护者 | `feat/v0.3-identity-manifest` | 反流 JARVIS USAGE_MANUAL §19 |
-| **I. 飞书 (Lark) export 适配器** | contributor | `feat/v0.3-lark-adapter` | 全新 (无上游反流) |
-| **J. 钉钉 (DingTalk) export 适配器** | contributor | `feat/v0.3-dingtalk-adapter` | 全新 |
-| **K. benchmarks/cn_multiparty/** | 维护者 | `feat/v0.3-cn-benchmark-suite` | 全新 — 5 个可复现微信 / QQ 场景 |
+## 提议路线图变更
 
-### v0.4 — 音频 + 声纹 (3 条并行 track)
-
-| Track | Owner | Branch |
-|---|---|---|
-| **L. SenseVoice ASR 反流** | contributor | `feat/v0.4-sensevoice-asr` |
-| **M. 跨 session voice manifest** | contributor | `feat/v0.4-voice-manifest` |
-| **N. `memexa 会议纪要 <session>`** | contributor | `feat/v0.4-meeting-summary` |
-
-### Contributor onboarding
-
-≥ 1 contributor 上线时, 维护者每个 release 开一个 "v0.X coordination"
-Discussion thread; track A–N 各自 file 为独立 issue, 标
-`good-first-issue` 或 `help-wanted`。每个 track 自带 `tests/...`
-隔离 scope, 并行 PR 不互踩。
-
----
-
-## 上游 JARVIS 反流状态 (LIVE 能力清单)
-
-| JARVIS LIVE 能力 | OSS 反流目标 | 状态 |
-|---|---|---|
-| 6 source (WeChat / QQ / Email / Browser / Claude Code / Audio) | v0.1 | ✅ 已 ship |
-| 14 查询 subcmd (基础 9 + 高级 5) | v0.1 | ✅ 已 ship |
-| Streaming POST + verify + dead-letter retry | v0.1 | ✅ 已 ship |
-| Doc source (file_sha1 绑定, .md/.pdf/.docx/.txt) | **v0.3** | 反流待办 |
-| QQ db-only (NapCat → SQLCipher 直读) | **v0.3** | 反流待办 |
-| Identity manifest 跨别名收敛 | **v0.3** | 反流待办 |
-| SenseVoice ASR + voice enroll | **v0.4** | 反流待办 |
-| MCP server entry-point | **v0.5** | OSS 新建 |
-| Schema drift sanitize (5 类) | **v0.6** | 反流待办 |
-| 5 driver rc=2 graceful-skip pattern | **v0.6** | 反流待办 |
-| Mac failover wrappers (PG stale-lock + hindsight pg_isready) | v0.5 docs | 反流待办 |
-| Win cron + Mac LaunchAgent + sys_monitor dashboard | **v0.5** | 反流待办 |
-
-JARVIS 上游保持实验边界；OSS 反流在能力在 JARVIS LIVE ≥ 4 周无回退后
-才做。这样 OSS 用户拿到的是真实生产负载验证过的能力。
+在 **Ideas** 类目开 Discussion, 写: 加什么 / 砍什么 / 落哪个 milestone /
+你是否愿意实现。维护者一段话回 yes / no / later。

--- a/docs/cost.md
+++ b/docs/cost.md
@@ -1,0 +1,100 @@
+# Cost estimation
+
+**English** · [中文](cost.zh.md)
+
+Last updated: 2026-05-16. Prices change; verify before relying on
+absolute numbers. The ratios between providers are more stable than
+the absolute values.
+
+memexa's core extraction pipeline calls a chat-completions endpoint
+twice per batch of conversation messages: once as a gatekeeper that
+filters HIGH / MEDIUM / LOW priority, once as the actual extractor
+that produces a V2 envelope. Tier 0 (`memexa demo`) does not call any
+LLM. Tier 1 and Tier 2 do.
+
+## Provider price table
+
+| Provider | Model | Input ¥/M | Output ¥/M | Notes |
+|---|---|---|---|---|
+| **DeepSeek** | V4 Flash | 1.0 | 2.0 | Cache hit: 0.2 / 2 |
+| **DeepSeek** | V4 Pro | 3.0 | 6.0 | 75 % off through 2026-05-31, then 12 / 24 list |
+| **Qwen** | qwen-plus | ~4 | ~12 | Roughly 4× DeepSeek Flash |
+| **Moonshot** | moonshot-v1-32k | ~12 | ~12 | Premium Chinese option |
+| **OpenAI** | gpt-4o | ~18 | ~72 | Roughly 10–15× DeepSeek Flash |
+| **OpenAI** | gpt-4o-mini | ~1 | ~4 | Cheap but quality drops on Chinese |
+| **Anthropic** | Claude 4.7 Sonnet | ~22 | ~110 | Roughly 12–18× DeepSeek Flash |
+| **Self-hosted (Ollama / vLLM)** | any | ~0 | ~0 | Hardware amortised separately |
+
+Sources: [DeepSeek API pricing](https://api-docs.deepseek.com/quick_start/pricing/),
+provider price pages as of 2026-05-16, RMB rates from `chat-deep.ai/pricing`.
+
+## Typical call volume per memexa workload
+
+| Tier | Batches per run | Tokens per batch (input / output) | LLM calls |
+|---|---|---|---|
+| Tier 0 (`memexa demo`) | 0 | 0 / 0 | 0 |
+| Tier 1 (≈ 100 messages of your own) | ~20 | 2k / 1k | 40 (20 gate + 20 extract) |
+| Tier 2 daily light (≈ 300 messages / day) | ~60 | 2k / 1k | 120 / day |
+| Tier 2 daily medium (≈ 1 000 messages / day) | ~200 | 2k / 1k | 400 / day |
+| Tier 2 daily heavy (≈ 5 000 messages / day) | ~1 000 | 2k / 1k | 2 000 / day |
+
+A batch ≈ five to ten chat messages plus a manifest slice. Input
+side is dominated by the manifest and system prompt, not the messages
+themselves. Output side is a single V2 envelope JSON object.
+
+## Cost per workload (recommended model combination)
+
+The recommended combination for Chinese workloads is **DeepSeek V4
+Flash as the gatekeeper** + **DeepSeek V4 Pro as the extractor**. This
+puts the cheaper model on the high-volume gate-keeping path and the
+better model only on the cards the gate marked as worth extracting.
+
+| Workload | Calls/month | Gate cost ¥ | Extract cost ¥ | Total ¥/month | Total $/month |
+|---|---|---|---|---|---|
+| Tier 1 one-shot (≈ 100 msg) | 40 | 0.06 | 0.24 | **0.30** | **≈ $0.04** |
+| Tier 2 light (≈ 9 000 msg/month) | 3 600 | 5.4 | 21.6 | **27** | **≈ $3.8** |
+| Tier 2 medium (≈ 30 000 msg/month) | 12 000 | 18 | 72 | **90** | **≈ $12.7** |
+| Tier 2 heavy (≈ 150 000 msg/month) | 60 000 | 90 | 360 | **450** | **≈ $63** |
+
+If you swap the Pro extractor for V4 Flash, divide the extract column
+by three. If you swap the gatekeeper for V4 Pro (over-pay-for-quality),
+multiply the gate column by three. If you swap to GPT-4o on extract,
+multiply the extract column by twelve.
+
+## Other model combinations
+
+| Combination | Tier 2 medium ¥/month | Tier 2 medium $/month | Notes |
+|---|---|---|---|
+| **DeepSeek Flash + DeepSeek Flash** | 36 | $5 | All-cheap baseline |
+| **DeepSeek Flash + DeepSeek Pro** | 90 | $13 | Recommended |
+| **DeepSeek Flash + Qwen plus** | ~200 | $28 | If your account has Qwen credits |
+| **DeepSeek Flash + GPT-4o-mini** | 60 | $8 | English-mostly workloads |
+| **DeepSeek Flash + GPT-4o** | 870 | $123 | If money is no object |
+| **Self-hosted Qwen 14B via vLLM** | 0 (+ hardware) | 0 (+ hardware) | If you have a GPU |
+
+## Cost monitoring
+
+After ingestion the dashboard's **API usage** panel
+(`http://127.0.0.1:8765`) reports per-day call counts and cumulative
+cost estimates broken down by `gate` / `extract`. Track this for the
+first week to verify the actual monthly cost matches the table above.
+
+For a hard ceiling, set `MEMEXA_API_BUDGET_DAILY=10` (RMB) in
+`.env`. The driver respects this and stops calling the LLM once
+the day's cumulative cost crosses the threshold; cards remain
+queued and resume on the next reset at 00:00 local time.
+
+## Free-tier path
+
+If you do not want to pay for an API at all, two options exist:
+
+1. **Tier 0 demo only.** `memexa demo` is free forever, runs against
+   the bundled synthetic dataset, and shows the query flow honestly.
+2. **Self-hosted LLM.** Run Qwen 14B (or any OpenAI-compatible model)
+   on your own hardware via vLLM or Ollama, and point
+   `MEMEXA_REMOTE_LLM_BASE_URL` at `http://127.0.0.1:11434/v1`. There
+   is no monthly API bill; the cost moves to GPU electricity.
+
+The first option is the suggested first stop; the second is suggested
+for users who want to ingest tens of thousands of messages per day and
+do not want a recurring API bill.

--- a/docs/cost.zh.md
+++ b/docs/cost.zh.md
@@ -1,0 +1,88 @@
+# 成本估算
+
+[English](cost.md) · **中文**
+
+最后更新: 2026-05-16. 价格会变, 用绝对数字前请核实。provider 之间的相
+对比例比绝对值稳定。
+
+memexa 核心抽取流程每个 batch 调 chat-completions 端点 2 次: 1 次
+gatekeeper 筛 HIGH / MEDIUM / LOW 优先级, 1 次 extractor 真抽 V2
+envelope。Tier 0 (`memexa demo`) 不调任何 LLM。Tier 1 和 Tier 2 调。
+
+## Provider 价格表
+
+| Provider | 模型 | 输入 ¥/M | 输出 ¥/M | 备注 |
+|---|---|---|---|---|
+| **DeepSeek** | V4 Flash | 1.0 | 2.0 | Cache 命中: 0.2 / 2 |
+| **DeepSeek** | V4 Pro | 3.0 | 6.0 | 75% 优惠至 2026-05-31, 之后 12 / 24 |
+| **Qwen** | qwen-plus | ~4 | ~12 | 约 DeepSeek Flash 4× |
+| **Moonshot** | moonshot-v1-32k | ~12 | ~12 | 中文 premium 选项 |
+| **OpenAI** | gpt-4o | ~18 | ~72 | 约 DeepSeek Flash 10-15× |
+| **OpenAI** | gpt-4o-mini | ~1 | ~4 | 便宜但中文质量降 |
+| **Anthropic** | Claude 4.7 Sonnet | ~22 | ~110 | 约 DeepSeek Flash 12-18× |
+| **自托管 (Ollama / vLLM)** | 任意 | ~0 | ~0 | 硬件成本另算 |
+
+来源: [DeepSeek API pricing](https://api-docs.deepseek.com/quick_start/pricing/),
+各 provider 2026-05-16 价格页, RMB 汇率取自 `chat-deep.ai/pricing`。
+
+## memexa 各 workload 典型调用量
+
+| Tier | 每跑 batches 数 | Token (输入 / 输出) | LLM 调用次数 |
+|---|---|---|---|
+| Tier 0 (`memexa demo`) | 0 | 0 / 0 | 0 |
+| Tier 1 (≈ 100 条自己消息) | ~20 | 2k / 1k | 40 (20 gate + 20 extract) |
+| Tier 2 每日轻量 (≈ 300 条/天) | ~60 | 2k / 1k | 120 / 天 |
+| Tier 2 每日中等 (≈ 1000 条/天) | ~200 | 2k / 1k | 400 / 天 |
+| Tier 2 每日重度 (≈ 5000 条/天) | ~1000 | 2k / 1k | 2000 / 天 |
+
+一个 batch ≈ 5-10 条聊天消息 + manifest slice。输入侧主要是 manifest 和
+system prompt, 不是消息本身。输出侧是单个 V2 envelope JSON。
+
+## 推荐模型组合的 workload 成本
+
+中文 workload 推荐组合: **DeepSeek V4 Flash 当 gatekeeper** +
+**DeepSeek V4 Pro 当 extractor**。便宜模型放高频 gate-keeping 路径,
+好模型只跑 gate 标过 worth 抽的卡。
+
+| Workload | 月调用 | Gate ¥ | Extract ¥ | 月总 ¥ | 月总 $ |
+|---|---|---|---|---|---|
+| Tier 1 单次 (≈ 100 msg) | 40 | 0.06 | 0.24 | **0.30** | **≈ $0.04** |
+| Tier 2 轻量 (≈ 9000 msg/月) | 3 600 | 5.4 | 21.6 | **27** | **≈ $3.8** |
+| Tier 2 中等 (≈ 30000 msg/月) | 12 000 | 18 | 72 | **90** | **≈ $12.7** |
+| Tier 2 重度 (≈ 150000 msg/月) | 60 000 | 90 | 360 | **450** | **≈ $63** |
+
+把 Pro extractor 换成 Flash, extract 列除 3。把 gatekeeper 换成 Pro
+(质量过付费), gate 列乘 3。把 extractor 换 GPT-4o, extract 列乘 12。
+
+## 其他模型组合
+
+| 组合 | Tier 2 中等 ¥/月 | Tier 2 中等 $/月 | 备注 |
+|---|---|---|---|
+| **DeepSeek Flash + DeepSeek Flash** | 36 | $5 | 全便宜 baseline |
+| **DeepSeek Flash + DeepSeek Pro** | 90 | $13 | 推荐 |
+| **DeepSeek Flash + Qwen plus** | ~200 | $28 | 账号有 Qwen 额度时 |
+| **DeepSeek Flash + GPT-4o-mini** | 60 | $8 | 英文为主 workload |
+| **DeepSeek Flash + GPT-4o** | 870 | $123 | 不差钱 |
+| **自托管 Qwen 14B via vLLM** | 0 (+ 硬件) | 0 (+ 硬件) | 有 GPU 的话 |
+
+## 成本监控
+
+摄入后, dashboard 的 **API usage** panel (`http://127.0.0.1:8765`)
+每日 print 调用次数 + 累积成本估算, 按 `gate` / `extract` 拆。
+第 1 周看一遍, 验证实际月成本符合上表。
+
+硬上限: `.env` 设 `MEMEXA_API_BUDGET_DAILY=10` (RMB)。driver 尊重该
+阈值, 当日累积成本超出后停调 LLM; cards 排队等次日 00:00 重置。
+
+## 完全免费路径
+
+不想付 API 费用, 2 个选项:
+
+1. **只跑 Tier 0 demo**。`memexa demo` 永远免费, 跑合成数据集, 诚实
+   展示查询流程。
+2. **自托管 LLM**。用 vLLM 或 Ollama 在自己硬件上跑 Qwen 14B (或任意
+   OpenAI 兼容模型), `MEMEXA_REMOTE_LLM_BASE_URL` 指 `http://127.0.0.1:
+   11434/v1`。没有月费 API 账单; 成本转到 GPU 电费。
+
+第 1 个适合新用户先看一眼; 第 2 个适合想每天摄入几万条 + 不想长期付
+API 费的用户。

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -2,126 +2,258 @@
 
 **English** · [中文](quickstart.zh.md)
 
-> Get to your first query in ≈ 30 minutes on a clean Win or macOS box.
-> Linux users follow [deployment/docker-compose.md](deployment/docker-compose.md).
+Three tiers, pick the one that matches how deep you want to go on the
+first day. The thirty-second tier needs nothing but Python; the
+five-minute tier adds an LLM API key; the thirty-minute tier is the
+full self-hosted production deployment.
 
-## 0. Prerequisites
+| Tier | Time | What you do | What you need |
+|---|---|---|---|
+| **Tier 0** | 30 seconds | See what the project does on synthetic data | Python 3.10+ |
+| **Tier 1** | 5 minutes | Ingest one of your own sources and run real queries | Python 3.10+, LLM API key |
+| **Tier 2** | 30 minutes | Full production deployment with cron + dashboard + all six sources | Python 3.10+, Docker Desktop, LLM API key, ~8 GB free RAM |
 
-- Python **3.10+**
-- Docker (for the Hindsight memory backend) **or** a local PostgreSQL
-  16+ with pgvector installed.
-- An OpenAI-compatible chat-completions endpoint (vLLM / Ollama /
-  LiteLLM proxy / DeepSeek API / 通义 / Moonshot / OpenRouter / etc).
-- ~8 GB free RAM during ingestion (LLM extractor lives in a separate
-  process; this is for BGE-M3 + your code).
+---
 
-## 1. Install
+## Tier 0 — thirty-second walkthrough
+
+memexa is designed for two audiences: **humans** running queries in
+a terminal, and **AI agents** (Claude Code, Cursor, Cline) invoking
+memexa as a subprocess. Tier 0 has a path for each.
+
+### For humans
+
+```bash
+pip install --pre memexa
+memexa demo
+```
+
+What you should see:
+
+```
+memexa demo  —  thirty-second onboarding
+────────────────────────────────────────────
+[1/3] Ingesting the bundled synthetic dataset (stub extractor) ...
+      ✓ Ingested 26 cards across 6 sources
+        (wechat=8, qq=4, email=4, browser=4, claude=3, audio=3).
+
+[2/3] Running five sample queries against the in-memory set ...
+  ▸ memexa quick 'Alice'
+     [wechat  2024-01-08] Alice 把组会改到周三下午三点
+     [qq      2024-01-05] Alice 推荐 DDIA 第 5 章
+     ...
+  ▸ memexa arc 'Alice ↔ Bob'
+     ...
+  ▸ memexa timeline '2024-01'
+     ...
+  ▸ memexa pending '(commitment cards)'
+     ...
+  ▸ memexa topic 'DDIA'
+     ...
+
+[3/3] Done. Next steps:
+      • memexa init       — scaffold ~/.memexa/ config
+      • memexa doctor     — self-diagnostic against your backend
+      • docs/quickstart.md — Tier 1 (5 min) or Tier 2 (30 min)
+```
+
+No Docker. No LLM API key. No configuration. This is the honest first
+look at what the project does.
+
+If `memexa demo` fails, see
+[`docs/troubleshooting.md#tier-0`](troubleshooting.md#tier-0).
+
+### For AI agents
+
+```bash
+pip install --pre memexa
+# Agent invokes via its shell tool with --json for structured output:
+memexa quick "<question>" --json
+memexa arc "<person>" --json
+memexa timeline --start 2024-01-01 --end 2024-02-01 --json
+```
+
+All fourteen query subcommands support `--json` starting in v0.1.x.
+The agent contract — seven hard rules, decision table, composition
+patterns — lives in [`docs/for_agents.md`](for_agents.md). Native
+MCP integration (`memexa-mcp` server + `.mcp.json`) ships in v0.5;
+until then the shell-subprocess path above is the first-class agent
+integration and it works in any agent runtime with a shell tool.
+
+---
+
+## Tier 1 — five-minute walkthrough with your own data
+
+Use Tier 1 when Tier 0 satisfied you and you want to point the
+pipeline at one of your own sources. Claude Code session history is
+the easiest source to start with because no export tool or app
+configuration is required.
+
+### 1. Scaffold config
+
+```bash
+memexa init
+# → creates ~/.memexa/{aliases.yaml, identity.yaml, .env}
+```
+
+Open `~/.memexa/.env` and fill in your LLM provider. The recommended
+default for Chinese workloads is DeepSeek (see
+[`docs/cost.md`](cost.md) for full price comparison):
+
+```
+MEMEXA_REMOTE_LLM_BASE_URL=https://api.deepseek.com
+MEMEXA_REMOTE_LLM_API_KEY=sk-...
+MEMEXA_REMOTE_LLM_GATE_MODEL=deepseek-v4-flash
+MEMEXA_REMOTE_LLM_EXTRACT_MODEL=deepseek-v4-pro
+```
+
+Typical first-run cost: about ¥0.30 per 1 000 messages with the above
+combination. Tier 1 against your own Claude Code projects directory
+will consume on the order of ¥0.10–¥1 depending on volume.
+
+### 2. Ingest one source
+
+```bash
+memexa ingest claude-code --from ~/.claude/projects/
+```
+
+The ingest command runs the same two-LLM extraction pipeline that
+Tier 2 uses but skips the cron-driven scheduling and the full six-
+source orchestrator. Expected runtime: 1–5 minutes for a few hundred
+sessions.
+
+### 3. Query
+
+```bash
+memexa quick "what did I work on last week"
+memexa topic "<a project name you actually have>"
+memexa pending
+```
+
+You should see real cards with real Chinese narrative (assuming your
+sessions are in Chinese) and per-claim citations back to the original
+session transcripts.
+
+### 4. (Optional) Doctor
+
+```bash
+memexa doctor
+```
+
+Self-diagnostic against the backend. Useful if a query returned
+unexpected zero cards.
+
+> **Tier 1 caveat**: Tier 1 currently writes into the same Hindsight-
+> compatible backend that Tier 2 uses. v0.3 will ship `memexa backend
+> --embedded` so this step does not need Docker at all. Until then,
+> Tier 1 either reuses a running Tier 2 backend or runs in process-
+> local SQLite mode (see `MEMEXA_HINDSIGHT_URL=memory://` in
+> `docs/configuration.md`).
+
+---
+
+## Tier 2 — full production deployment (thirty minutes)
+
+Use Tier 2 when you want the project running on a schedule across all
+six sources, with a dashboard and a memory backend that survives
+reboots.
+
+### 1. Tooling
+
+Pick the deployment guide that matches your platform:
+
+- macOS — [`docs/deployment/macos.md`](deployment/macos.md)
+- Windows — [`docs/deployment/windows.md`](deployment/windows.md)
+- Linux + Docker — [`docs/deployment/docker-compose.md`](deployment/docker-compose.md)
+
+All three guides install the same five components: Python 3.10+, Git,
+Docker Desktop or `docker-compose-plugin`, a clone of the repository,
+and the `pip install -e ".[dev]"` editable install.
+
+### 2. Clone + install
 
 ```bash
 git clone https://github.com/labazhou2024/memexa.git memexa
 cd memexa
 python -m venv .venv
-. .venv/bin/activate     # PowerShell: .venv\Scripts\Activate.ps1
-pip install -e .[dev]
+. .venv/bin/activate    # PowerShell: .\.venv\Scripts\Activate.ps1
+pip install -e ".[dev]"
 ```
 
-## 2. Configure
+### 3. Configure
 
 ```bash
-# environment (loaded by docker-compose + Makefile, not the Python code)
 cp .env.example .env
 $EDITOR .env
 
-# user config (read by the Python code at runtime)
 mkdir -p ~/.memexa
-cp config/aliases.example.yaml   ~/.memexa/aliases.yaml
-cp config/identity.example.yaml  ~/.memexa/identity.yaml
-$EDITOR ~/.memexa/aliases.yaml
-$EDITOR ~/.memexa/identity.yaml
+cp config/aliases.example.yaml  ~/.memexa/aliases.yaml
+cp config/identity.example.yaml ~/.memexa/identity.yaml
+$EDITOR ~/.memexa/{aliases,identity}.yaml
 ```
 
-The bare minimum to set:
+Minimum required fields in `.env`:
 
-- `~/.memexa/aliases.yaml` → list of strings the system should match
-  to "you" (your name, nicknames, email prefixes, etc.).
-- `.env` → `MEMEXA_REMOTE_LLM_BASE_URL`, `MEMEXA_REMOTE_LLM_API_KEY`,
-  `MEMEXA_REMOTE_LLM_GATE_MODEL`, `MEMEXA_REMOTE_LLM_EXTRACT_MODEL`.
+- `MEMEXA_REMOTE_LLM_BASE_URL`
+- `MEMEXA_REMOTE_LLM_API_KEY`
+- `MEMEXA_REMOTE_LLM_GATE_MODEL`
+- `MEMEXA_REMOTE_LLM_EXTRACT_MODEL`
 
-## 3. Bring up the memory backend
+### 4. Bring up the memory backend
 
 ```bash
-docker compose -f docker-compose.example.yml up -d
-# Wait ~30 s for pgvector + Hindsight to come online
-curl -sf http://127.0.0.1:8888/healthz | jq .
-# {"status":"ok"}
+make backend-up
+# or: docker compose -f docker-compose.example.yml up -d
 ```
 
-## 4. First query (demo dataset)
+Wait ~30 seconds for pgvector + Hindsight to come online. The
+Makefile target polls `:8888/healthz` and exits when ready.
+
+### 5. Ingest the demo dataset, then your own
 
 ```bash
-# Sanity-check the bundle parses without any backend running
-python -m examples.demo_dataset.ingest --dry-run
-# → prints "total = 26 cards across 6 sources"
-
-# Ingest into a real backend (requires step 3 to have succeeded)
-make demo-ingest
-
-# Confirm the install end-to-end
-memexa doctor
-# → [ok] primary /healthz returned 200
-# → [ok] bank 'memory_full_v5' has N nodes
-# → [ok] LLM/gate ... responded 200
-
-# Run a few subcommands
-python -m memexa.core.memory_query topic    "<your-keyword>"
-python -m memexa.core.memory_query arc      "<entity>"
-python -m memexa.core.memory_query timeline --start 2024-01-01 --end 2024-02-01
+make demo-ingest        # ingest synthetic dataset against the real backend
+memexa doctor           # confirm everything is wired up
+make demo-query         # run four sample queries
 ```
 
-## 5. Wire up your own data
+Then point each source builder at your own data. Detailed per-source
+onboarding lives in [`docs/integrations/`](integrations/).
 
-Each source has a builder that converts raw exports → batch JSON, plus a
-driver that runs the extraction pipeline on a 6-hour schedule.
+### 6. Schedule the cron
 
-Detailed per-source onboarding:
+Each deployment guide includes a `register-cron.sh` (macOS / Linux)
+or `register-tasks.ps1` (Windows) that installs a six-hour incremental
+job per driver plus the dashboard service.
 
-- **WeChat** — export with [`WeChatMsg`](https://github.com/LC044/WeChatMsg)
-  or [`wechatDataBackup`](https://github.com/git-jiadong/wechatDataBackup);
-  point `v5_wechat_batch_builder.py` at the JSON.
-- **QQ** — set `MEMEXA_QQ_ID`; the builder reads
-  `~/Documents/Tencent Files/<qq-id>/nt_qq/nt_db/nt_msg.db` directly.
-- **Email** — IMAP credentials in `~/.memexa/identity.yaml`.
-- **Browser** — point at your browser profile's `History` SQLite file.
-- **Claude Code** — point at `~/.claude/projects/`.
-- **Audio** — drop `.wav`/`.m4a` files into `data/audio/inbox/`; the
-  audio driver picks them up.
-
-## 6. Schedule the cron
-
-Pick a deployment guide and follow it end-to-end:
-
-- [deployment/macos.md](deployment/macos.md) — launchd plist for each driver
-- [deployment/windows.md](deployment/windows.md) — Scheduled Tasks (`schtasks`)
-- [deployment/docker-compose.md](deployment/docker-compose.md) — Linux + Docker
-
-## 7. Open the dashboard
+### 7. Open the dashboard
 
 ```bash
 python -m memexa.dashboard.sys_monitor.server
-# Open http://127.0.0.1:8765
+# → http://127.0.0.1:8765
 ```
 
-You should see seven live panels: Win/Mac/GPU CPU+memory, API usage,
-memory system, cron health, graph queries, six-source pending, audio
+Seven live panels: Win/Mac/GPU CPU+memory, API usage, memory system
+health, cron status, recent graph queries, six-source pending, audio
 pipeline.
 
-## 8. Troubleshooting
+---
 
-- *Query returns 0 cards even though data is ingested* — see
-  [usage_guide.md#troubleshooting](usage_guide.md#troubleshooting).
-- *Extractor LLM returns malformed JSON* — see
-  [lessons_learned/05_qwen3_no_think.md](lessons_learned/05_qwen3_no_think.md).
-- *PG marker drift* — see
-  [lessons_learned/03_pg_aware_pending.md](lessons_learned/03_pg_aware_pending.md).
+## Troubleshooting
 
-Open an issue at `memexa/issues/new` if none of the above fits.
+If a step fails, the first stop is
+[`docs/troubleshooting.md`](troubleshooting.md). Common Tier 0/1/2
+failure modes are covered there with the exact remediation command.
+
+For backend or LLM-provider failures, run `memexa doctor` first — it
+runs a four-step probe (backend health, bank stats, LLM round-trip,
+identity manifest) and prints a per-step pass/fail.
+
+For query-returns-zero-cards or extractor-malformed-JSON, see the
+lessons-learned series:
+
+- [`lessons_learned/03_pg_aware_pending.md`](lessons_learned/03_pg_aware_pending.md) — PG marker drift
+- [`lessons_learned/05_qwen3_no_think.md`](lessons_learned/05_qwen3_no_think.md) — Qwen3 `/no_think` directive
+
+Open an issue at <https://github.com/labazhou2024/memexa/issues/new>
+if none of the above fits.

--- a/docs/quickstart.zh.md
+++ b/docs/quickstart.zh.md
@@ -1,123 +1,238 @@
-# 快速开始
+# Quickstart
 
 [English](quickstart.md) · **中文**
 
-> 在干净的 Win / macOS 上 ≈ 30 分钟跑到第一次查询。Linux 用户走
-> [deployment/docker-compose.md](deployment/docker-compose.md)。
+3 个 Tier, 按你第一天想钻多深选。Tier 0 只要 Python; Tier 1 加 LLM API
+key; Tier 2 是完整自托管生产部署。
 
-## 0. 前置依赖
+| Tier | 时间 | 你做什么 | 你需要什么 |
+|---|---|---|---|
+| **Tier 0** | 30 秒 | 在合成数据上看项目能做什么 | Python 3.10+ |
+| **Tier 1** | 5 分钟 | 接 1 个你自己的 source, 跑真查询 | Python 3.10+, LLM API key |
+| **Tier 2** | 30 分钟 | 生产部署: cron + dashboard + 6 个 source | Python 3.10+, Docker Desktop, LLM API key, ~8 GB 空闲内存 |
 
-- Python **3.10+**
-- Docker (跑 Hindsight 记忆后端) **或** 本地装好 pgvector 的 PostgreSQL 16+
-- 一个 OpenAI-compatible chat-completions endpoint (vLLM / Ollama / LiteLLM
-  proxy / DeepSeek API / 通义 / Moonshot / OpenRouter / etc)
-- 摄入期间 ~8 GB 空闲内存 (LLM extractor 独立进程; 这是 BGE-M3 + 你的代码)
+---
 
-## 1. 安装
+## Tier 0 — 30 秒 walkthrough
+
+memexa 服务两类用户: **人类** 在终端跑查询, 和 **AI agent**
+(Claude Code / Cursor / Cline) 把 memexa 当 subprocess 调。Tier 0
+两类各有一条路径。
+
+### 人类用户路径
+
+```bash
+pip install --pre memexa
+memexa demo
+```
+
+你应该看到:
+
+```
+memexa demo  —  thirty-second onboarding
+────────────────────────────────────────────
+[1/3] Ingesting the bundled synthetic dataset (stub extractor) ...
+      ✓ Ingested 26 cards across 6 sources
+        (wechat=8, qq=4, email=4, browser=4, claude=3, audio=3).
+
+[2/3] Running five sample queries against the in-memory set ...
+  ▸ memexa quick 'Alice'
+     [wechat  2024-01-08] Alice 把组会改到周三下午三点
+     [qq      2024-01-05] Alice 推荐 DDIA 第 5 章
+     ...
+  ▸ memexa arc 'Alice ↔ Bob' ...
+  ▸ memexa timeline '2024-01' ...
+  ▸ memexa pending '(commitment cards)' ...
+  ▸ memexa topic 'DDIA' ...
+
+[3/3] Done. Next steps:
+      • memexa init       — scaffold ~/.memexa/ config
+      • memexa doctor     — self-diagnostic against your backend
+      • docs/quickstart.zh.md — Tier 1 (5 min) 或 Tier 2 (30 min)
+```
+
+不需要 Docker, 不需要 LLM API key, 不需要任何配置。这是项目实际能做什么
+的诚实第一眼。
+
+如果 `memexa demo` 失败, 见
+[`docs/troubleshooting.zh.md#tier-0`](troubleshooting.zh.md#tier-0)。
+
+### AI agent 路径
+
+```bash
+pip install --pre memexa
+# Agent 通过 shell 工具调, 加 --json 拿结构化输出:
+memexa quick "<问题>" --json
+memexa arc "<人名>" --json
+memexa timeline --start 2024-01-01 --end 2024-02-01 --json
+```
+
+14 个查询子命令全部从 v0.1.x 起支持 `--json`。Agent 契约 — 7 条
+hard rule / 决策表 / 组合模式 — 写在
+[`docs/for_agents.zh.md`](for_agents.zh.md)。原生 MCP integration
+(`memexa-mcp` server + `.mcp.json`) 在 v0.5 ship; 在此之前 shell
+subprocess 是 first-class agent integration, 任何带 shell 工具的
+agent runtime 都能用。
+
+---
+
+## Tier 1 — 5 分钟 walkthrough, 用你自己的数据
+
+Tier 0 看了满意后, 想把 pipeline 指向你自己的 source 试一下 — 用 Tier 1。
+最简单的入口是 Claude Code session 历史, 不需要导出工具, 不需要应用配置。
+
+### 1. 初始化配置
+
+```bash
+memexa init
+# → 创建 ~/.memexa/{aliases.yaml, identity.yaml, .env}
+```
+
+打开 `~/.memexa/.env` 填 LLM provider。中文场景推荐 DeepSeek
+(完整对比见 [`docs/cost.zh.md`](cost.zh.md)):
+
+```
+MEMEXA_REMOTE_LLM_BASE_URL=https://api.deepseek.com
+MEMEXA_REMOTE_LLM_API_KEY=sk-...
+MEMEXA_REMOTE_LLM_GATE_MODEL=deepseek-v4-flash
+MEMEXA_REMOTE_LLM_EXTRACT_MODEL=deepseek-v4-pro
+```
+
+典型首跑成本: 上面组合每 1000 条消息约 **¥0.30**。Tier 1 跑你自己的
+Claude Code projects 目录, 按消息量约 ¥0.10-¥1。
+
+### 2. 接 1 个 source
+
+```bash
+memexa ingest claude-code --from ~/.claude/projects/
+```
+
+`ingest` 命令跑的是 Tier 2 同一套双 LLM 抽取流程, 只跳过 cron 调度和 6
+source orchestrator。预期耗时: 1-5 分钟 (几百个 session)。
+
+### 3. 查询
+
+```bash
+memexa quick "我上周做了什么"
+memexa topic "<你真有的项目名>"
+memexa pending
+```
+
+你应该看到真 cards + 真中文 narrative (如果你的 session 是中文) + 每条
+断言绑回原 session transcript 的 citation。
+
+### 4. (可选) Doctor
+
+```bash
+memexa doctor
+```
+
+后端 self-diagnostic。查询返 0 cards 时跑一遍能定位是哪一层出了问题。
+
+> **Tier 1 注意**: Tier 1 目前写入 Tier 2 同一套 Hindsight 兼容后端。
+> v0.3 会 ship `memexa backend --embedded`, 让这一步完全不需要 Docker。
+> 在 v0.3 之前, Tier 1 要么复用一个跑着的 Tier 2 backend, 要么走
+> process-local SQLite mode (见 `MEMEXA_HINDSIGHT_URL=memory://`,
+> [`docs/configuration.zh.md`](configuration.zh.md))。
+
+---
+
+## Tier 2 — 完整生产部署 (30 分钟)
+
+Tier 2 = 项目按 schedule 跨 6 source 跑, 含 dashboard, 含 reboot
+后能恢复的 memory backend。
+
+### 1. 工具链
+
+按你的平台选一个部署指南:
+
+- macOS — [`docs/deployment/macos.zh.md`](deployment/macos.zh.md)
+- Windows — [`docs/deployment/windows.zh.md`](deployment/windows.zh.md)
+- Linux + Docker — [`docs/deployment/docker-compose.zh.md`](deployment/docker-compose.zh.md)
+
+3 个指南装的是同 5 个组件: Python 3.10+, Git, Docker Desktop 或
+`docker-compose-plugin`, 仓库 clone, `pip install -e ".[dev]"`。
+
+### 2. Clone + 装包
 
 ```bash
 git clone https://github.com/labazhou2024/memexa.git memexa
 cd memexa
 python -m venv .venv
-. .venv/bin/activate     # PowerShell: .venv\Scripts\Activate.ps1
-pip install -e .[dev]
+. .venv/bin/activate    # PowerShell: .\.venv\Scripts\Activate.ps1
+pip install -e ".[dev]"
 ```
 
-## 2. 配置
+### 3. 配置
 
 ```bash
-# 环境变量 (docker-compose + Makefile 读, Python 代码不读)
 cp .env.example .env
 $EDITOR .env
 
-# 用户配置 (Python 运行时读)
 mkdir -p ~/.memexa
-cp config/aliases.example.yaml   ~/.memexa/aliases.yaml
-cp config/identity.example.yaml  ~/.memexa/identity.yaml
-$EDITOR ~/.memexa/aliases.yaml
-$EDITOR ~/.memexa/identity.yaml
+cp config/aliases.example.yaml  ~/.memexa/aliases.yaml
+cp config/identity.example.yaml ~/.memexa/identity.yaml
+$EDITOR ~/.memexa/{aliases,identity}.yaml
 ```
 
-最少要设的:
+`.env` 最少必填:
 
-- `~/.memexa/aliases.yaml` → 系统应该匹配成 "你" 的字符串列表 (你的名字 /
-  昵称 / 邮箱前缀 等)
-- `.env` → `MEMEXA_REMOTE_LLM_BASE_URL`, `MEMEXA_REMOTE_LLM_API_KEY`,
-  `MEMEXA_REMOTE_LLM_GATE_MODEL`, `MEMEXA_REMOTE_LLM_EXTRACT_MODEL`
+- `MEMEXA_REMOTE_LLM_BASE_URL`
+- `MEMEXA_REMOTE_LLM_API_KEY`
+- `MEMEXA_REMOTE_LLM_GATE_MODEL`
+- `MEMEXA_REMOTE_LLM_EXTRACT_MODEL`
 
-## 3. 启动记忆后端
+### 4. 起 memory backend
 
 ```bash
-docker compose -f docker-compose.example.yml up -d
-# 等 ~30 秒 pgvector + Hindsight 起来
-curl -sf http://127.0.0.1:8888/healthz | jq .
-# {"status":"ok"}
+make backend-up
+# 或: docker compose -f docker-compose.example.yml up -d
 ```
 
-## 4. 第一次查询 (用 demo 数据集)
+等 ~30 秒 pgvector + Hindsight 起来。Makefile target 自动 poll
+`:8888/healthz` 健康后才退出。
+
+### 5. 摄入 demo dataset, 再接你自己的
 
 ```bash
-# 不连后端先验证打包能解析
-python -m examples.demo_dataset.ingest --dry-run
-# → 打印 "total = 26 cards across 6 sources"
-
-# 真摄入到后端 (要 step 3 成功)
-make demo-ingest
-
-# 端到端确认装好了
-memexa doctor
-# → [ok] primary /healthz returned 200
-# → [ok] bank 'memory_full_v5' has N nodes
-# → [ok] LLM/gate ... responded 200
-
-# 跑几个子命令
-python -m memexa.core.memory_query topic    "<你的关键词>"
-python -m memexa.core.memory_query arc      "<某个实体>"
-python -m memexa.core.memory_query timeline --start 2024-01-01 --end 2024-02-01
+make demo-ingest        # 把合成数据集摄入真 backend
+memexa doctor           # 确认全链路通
+make demo-query         # 跑 4 个示例查询
 ```
 
-## 5. 接入你自己的数据
+接你自己的数据见 [`docs/integrations/`](integrations/), 每个 source
+有独立 onboarding 指南。
 
-每个 source 都有一个 builder 把原始 export 转成 batch JSON, 加一个
-driver 跑 6 小时一轮抽取 pipeline。
+### 6. 装 cron
 
-每个 source 的详细接入:
+每个部署指南包含 `register-cron.sh` (macOS / Linux) 或
+`register-tasks.ps1` (Windows), 装好每 6 小时跑一次的增量 driver +
+dashboard service。
 
-- **微信** — 用 [`WeChatMsg`](https://github.com/LC044/WeChatMsg) 或
-  [`wechatDataBackup`](https://github.com/git-jiadong/wechatDataBackup) 导出;
-  把 `v5_wechat_batch_builder.py` 指向那份 JSON。
-- **QQ** — 设 `MEMEXA_QQ_ID`; builder 直接读
-  `~/Documents/Tencent Files/<qq-id>/nt_qq/nt_db/nt_msg.db`。
-- **邮件** — IMAP 凭据填到 `~/.memexa/identity.yaml`。
-- **浏览器** — 指向浏览器 profile 里的 `History` SQLite。
-- **Claude Code** — 指向 `~/.claude/projects/`。
-- **语音** — 把 `.wav` / `.m4a` 文件丢到 `data/audio/inbox/`, audio driver
-  自己捡。
-
-## 6. 排 cron
-
-挑一个部署指南端到端跟着做:
-
-- [deployment/macos.md](deployment/macos.md) — 每个 driver 一个 launchd plist
-- [deployment/windows.md](deployment/windows.md) — Scheduled Tasks (`schtasks`)
-- [deployment/docker-compose.md](deployment/docker-compose.md) — Linux + Docker
-
-## 7. 打开 dashboard
+### 7. 打开 dashboard
 
 ```bash
 python -m memexa.dashboard.sys_monitor.server
-# 浏览器打开 http://127.0.0.1:8765
+# → http://127.0.0.1:8765
 ```
 
-应该看到 7 个 live 面板: Win/Mac/GPU CPU+内存, API usage, memory system,
-cron health, graph queries, six-source pending, audio pipeline。
+7 个 LIVE panel: Win/Mac/GPU CPU+memory / API usage / memory system /
+cron 健康 / 近期 graph queries / 6 source pending / audio pipeline。
 
-## 8. 故障排查
+---
 
-- *已摄入数据但查询返回 0 卡* — 见 [usage_guide.zh.md](usage_guide.zh.md)。
-- *Extractor LLM 返回坏 JSON* — 见
-  [lessons_learned/05_qwen3_no_think.md](lessons_learned/05_qwen3_no_think.md)。
-- *PG marker drift* — 见
-  [lessons_learned/03_pg_aware_pending.md](lessons_learned/03_pg_aware_pending.md)。
+## 故障排查
 
-以上都不对的话, 去 `memexa/issues/new` 提 issue。
+任一步失败, 第一站是 [`docs/troubleshooting.zh.md`](troubleshooting.zh.md)。
+Tier 0/1/2 常见失败模式都在那里, 含确切补救命令。
+
+后端或 LLM provider 问题, 先跑 `memexa doctor` — 它 4 步 probe (后端
+health + bank stats + LLM round-trip + identity manifest) 给逐步
+pass/fail。
+
+查询返 0 cards / extractor 输出 malformed JSON, 见 lessons-learned 系列:
+
+- [`lessons_learned/03_pg_aware_pending.md`](lessons_learned/03_pg_aware_pending.md) — PG marker drift
+- [`lessons_learned/05_qwen3_no_think.md`](lessons_learned/05_qwen3_no_think.md) — Qwen3 `/no_think`
+
+没找到的 issue: <https://github.com/labazhou2024/memexa/issues/new>。

--- a/docs/why.md
+++ b/docs/why.md
@@ -1,0 +1,193 @@
+# Why memexa
+
+**English** · [中文](why.zh.md)
+
+This page collects the design intent, the per-capability comparison
+against neighbouring OSS memory projects, and the user scenarios memexa
+is designed for. If you are looking for the install path, see
+[`docs/quickstart.md`](quickstart.md). If you are looking for the
+forward plan, see [`ROADMAP.md`](../ROADMAP.md).
+
+## Design intent
+
+The Chinese-language data this project ingests — WeChat / QQ / 飞书 /
+钉钉 multi-party group chats, Chinese email threads, Chinese audio —
+demands a different memory layer than the one Western dev tools
+typically build. Three properties matter:
+
+1. **Verbatim raw storage alongside structured extraction.** Group
+   chats are heterogeneous: some messages are jokes, some are critical
+   commitments. Summarising them up front loses information that
+   matters later. memexa stores every original message verbatim and
+   produces an LLM-extracted envelope alongside, never replacing the
+   raw text.
+
+2. **Per-claim citation back to the source sentence.** When a
+   deliverable template asserts "Y professor moved the group meeting
+   to Wednesday 3 pm," the user can click through to the original
+   message and see who said it, in which group, at what time. This is
+   the `evidence_quotes` field on every extracted envelope.
+
+3. **Cross-alias entity resolution.** A single person in a Chinese
+   group chat surfaces as `@张三`, `张老师`, `zhangsan@gmail.com`,
+   sometimes as a real-name signature. memexa learns these aliases
+   automatically with a four-phase zero-LLM algorithm and binds them
+   to a single canonical id.
+
+These three properties — verbatim + citation + canonicalization —
+together let the system handle high-accuracy retrieval over messy
+multi-party Chinese data, which is the actual use case for almost all
+the project's target users.
+
+## Comparison to neighbouring projects
+
+The OSS memory landscape in 2026 has three other major projects that a
+prospective user might consider:
+
+- **OpenHuman** (`tinyhumansai/openhuman`): Rust + Tauri desktop
+  assistant with 118+ Western SaaS integrations.
+- **MemPalace** (`MemPalace/mempalace`): Python dev tool with verbatim
+  storage and benchmark-driven retrieval (LongMemEval R@5 = 96.6 %).
+- **ReMe** (`agentscope-ai/ReMe`): Memory management kit for agents,
+  backed by the AgentScope ecosystem.
+
+The capability matrix below is the honest answer to "why pick memexa
+instead":
+
+| Capability | OpenHuman | MemPalace | ReMe | **memexa** |
+|---|---|---|---|---|
+| Storage model | 3 k-token markdown hierarchical summaries | Verbatim text with Zettelkasten literal index | Agent-context tool kit | **Verbatim raw + LLM-extracted V2 envelope** |
+| Multi-party group-chat role resolution | Summary collapses speaker roles | No role concept | Agent-level | ✅ V2 envelope `roles[]` + `identity_assertions` |
+| Per-claim citation back to original sentence | Summary already folded | ✅ verbatim returns raw | Agent-level | ✅ `evidence_quotes` binds every claim to its source sentence with `chunk_id` |
+| Cross-alias canonical id | Names only, no aliases | No entity concept | Agent-level | ✅ `identity_manifest` + four-phase zero-LLM algorithm |
+| Chinese relative-time parsing ("上周三") | Doc-time only | None | None | ✅ `time_resolutions` (ISO 8601 + relative anchor) |
+| Hallucination control on extraction | None — single-pass summarize | None — no extraction | None | ✅ Two-LLM gate + extract + DeepSeek arbiter quorum |
+| Native Chinese IM sources (WeChat / QQ / 飞书 / 钉钉) | None (Western OAuth only) | None | None | ✅ WeChat + QQ shipped; 飞书 + 钉钉 in v0.3 |
+
+The thesis is straightforward. Hierarchical summaries (OpenHuman) lose
+information; literal-text Zettelkasten (MemPalace) cannot disambiguate
+"who said what to whom" in a ten-person 微信群 chat history; agent-
+context kits (ReMe) operate at a different layer entirely. memexa
+keeps both verbatim raw and an LLM-extracted structured layer with
+per-claim citation, and ships the Chinese-IM ingestion paths the other
+projects have no reason to build.
+
+## Why memexa is agent-first, and why that matters
+
+A second differentiator that the comparison table does not surface
+clearly: memexa is the only project in this list with a **dedicated
+agent protocol document**. The fourteen subcommands and seven hard
+rules in [`for_agents.md`](for_agents.md) read like an API contract
+written for an LLM — strict, dense, with explicit failure modes that
+agents commonly hit (calling `topic` on a person's name, wrapping
+external parallelism around `topic`/`arc`, treating `pending` as a
+semantic recall instead of a calendar read).
+
+This matters because **the typical memexa user is not the human
+typing commands** — it is an AI agent (Claude Code, Cursor, Cline, or
+one the user wrote themselves) invoking memexa as a subprocess on the
+user's behalf. The CLI surface and the agent protocol are the same
+fourteen subcommands; the agent reads the protocol, the human reads
+the usage guide, both produce the same calls.
+
+This is why v0.2 ships **markdown workflow specs** (`docs/templates/
+weekly.md` etc.) instead of new CLI subcommands: the agent reads the
+spec at runtime and orchestrates the existing fourteen subcommands.
+Users add their own templates by copying a markdown file; no Python
+required.
+
+## Glossary
+
+A few project-specific terms used throughout the documentation:
+
+- **Verbatim raw + V2 envelope**: every ingested message is stored
+  unchanged; alongside it, a separate "V2 envelope" record carries
+  the LLM-extracted structured layer (narrative, entities,
+  evidence_quotes, time_resolutions, identity_assertions,
+  relation_assertions). Raw and extracted always coexist; the
+  extraction never replaces the original.
+
+- **Reflow**: porting a capability that has been LIVE for ≥ 4 weeks
+  in upstream development (without rollback) into the public memexa
+  repository. Each reflow requires a PII / abstraction audit before
+  merge so that no private data, real names, or system-specific
+  paths leak from upstream into the OSS codebase. The Chinese-IM
+  ingestion reflow (v0.3) and the audio + voice reflow (v0.4) are
+  the two main reflow milestones currently planned.
+
+- **Chinese-IM reflow** (v0.3 milestone): porting the QQ db-only
+  adapter (SQLCipher direct read), the local document source
+  (.md/.pdf/.docx/.txt with file-sha1 binding), the identity
+  manifest auto-learning algorithm, the WeChat PC backup ingestion
+  path, and new 飞书 / 钉钉 export adapters. The goal is to expand
+  the Chinese-IM coverage from WeChat + QQ today to four major
+  Chinese IM platforms plus local documents.
+
+- **Audio + voice reflow** (v0.4 milestone): porting the SenseVoice
+  ASR engine (Chinese CER ~6.8 %, 5× realtime, replacing Whisper),
+  the cross-session voice manifest (ECAPA-based "self vs speaker N"
+  resolution), and the multi-device audio merge (recording-pen +
+  phone + classroom voice memos deduplicated by content fingerprint).
+  Goal: Chinese audio recordings become a first-class source with
+  speaker disambiguation, not just transcripts.
+
+- **Workflow spec** (v0.2 milestone): a Markdown document under
+  `docs/templates/` that describes how an AI agent should orchestrate
+  the fourteen query subcommands to produce a specific deliverable
+  (weekly report, meeting brief, time-window recap). The spec is
+  read by the agent at runtime — no Python code is added to memexa
+  to ship a new spec.
+
+## User scenarios
+
+memexa is designed for five scenarios, all of which share the same
+backbone (ingestion + extract + graph + query) and differ only in the
+deliverable template on top.
+
+| Scenario | Typical user | Primary workflow (v0.2 +) |
+|---|---|---|
+| **Knowledge worker / PM / consultant** | Bilingual office worker, freelancer | `weekly` spec (cross-source weekly recap), `brief` spec (meeting prep on a person) |
+| **Researcher / student / academic** | University student, graduate research | `brief` spec (defense or talk prep on a topic), `retro` spec (project recap over a window) |
+| **Content creator / 自媒体** | 公众号 author, 知乎 answerer, 小红书 creator | `retro` spec (idea recovery), v0.7 community spec templates for material library |
+| **Small business / 个体户** | Freelance professional, small studio owner | `brief` spec (client / lead prep), `retro` spec (deal recap) |
+| **Self-quantified / GTD / privacy power user** | Self-hosted enthusiast, GTD practitioner | `memexa pending` query (cross-source to-do), `retro` spec (weekly review) |
+
+All five scenarios are first-class. v0.2 ships three workflow specs
+(`weekly` / `brief` / `retro` as markdown documents under
+`docs/templates/`) that cover the most common needs across all
+scenarios. The agent reads the spec at runtime, runs the relevant
+subset of the fourteen query subcommands, and composes a Markdown
+report with per-claim citations. v0.7 opens the same authoring path
+to users — a new template is a new markdown file, no Python required.
+
+## V2 envelope field reference
+
+For developers who want to understand what the extractor actually
+produces, every extracted card carries the following fields:
+
+- `narrative`: Chinese-language summary of the original event,
+  ≤ 200 characters.
+- `entities`: list of `{surface, kind, canonical_id?}` extracted from
+  the source. `kind` is one of `person` / `org` / `place` / `event` /
+  `thing`.
+- `evidence_quotes`: list of original sentences from the source that
+  justify the claims in `narrative`. **Every claim must be backed by
+  at least one quote**; this is enforced at extraction time.
+- `time_resolutions`: list of `{surface, iso_start, iso_end?,
+  anchor?}` — turns relative times ("上周三下午", "前天") into
+  absolute ISO 8601 timestamps.
+- `identity_assertions`: list of `{surface_a, surface_b, confidence}`
+  — claims that two surface forms refer to the same canonical entity.
+- `relation_assertions`: list of `{subject, predicate, object,
+  evidence}` — extracted relationships ("Y professor recommended
+  DDIA chapter 5 to Alice").
+- `roles[]`: per-message speaker role tags (sender / mentioned /
+  audience), allowing group-chat speaker disambiguation.
+- `salience`: 0.0 - 1.0 importance score; cards below the default
+  `0.4` floor are filtered from `session-context` injection.
+- `chunk_id` + `source_origin`: pointer back to the raw batch JSON
+  file the card was extracted from, so the user can always retrieve
+  the original message context.
+
+The thesis above is real because these fields are populated by every
+card; the citation flow is not an aspiration but a tested invariant.

--- a/docs/why.zh.md
+++ b/docs/why.zh.md
@@ -1,0 +1,150 @@
+# 为什么用 memexa
+
+[English](why.md) · **中文**
+
+本页收集设计意图、与相邻 OSS memory 项目的逐项能力对比、memexa 服务的
+5 类用户场景。装机路径见 [`docs/quickstart.zh.md`](quickstart.zh.md)。
+前瞻路线见 [`ROADMAP.zh.md`](../ROADMAP.zh.md)。
+
+## 设计意图
+
+memexa 摄入的中文数据 — 微信 / QQ / 飞书 / 钉钉 多人群聊、中文邮件长链、
+中文音频 — 要求一种和西方 dev tool 通常构建的不一样的 memory layer。
+三个核心属性:
+
+1. **Verbatim 原始存储与结构化抽取并存**。群聊是异构的: 有些是笑话, 有
+   些是关键承诺。前置摘要会丢掉之后才发现重要的信息。memexa 永远保留每
+   条原始消息 verbatim, 同时产出一份 LLM 抽取的 envelope, 但不替换原文。
+
+2. **每条断言可回溯到原句**。当 deliverable 模板写"Y 老师把组会改到
+   周三下午 3 点"时, 用户能点进去看到原始消息: 谁在哪个群什么时候说的。
+   这是每个 envelope 上的 `evidence_quotes` 字段。
+
+3. **跨别名实体收敛**。一个人在中文群里会以 `@张三` / `张老师` /
+   `zhangsan@gmail.com` / 实名签名 多种形式出现。memexa 用 4 阶段
+   0-LLM 算法自动学习这些别名, 全部绑到一个 canonical id 上。
+
+这三个属性 — verbatim + citation + canonicalization — 加在一起让系统
+能在脏乱的多人中文数据上做高准确度检索, 这正是项目几乎所有目标用户的
+真实用例。
+
+## 与相邻项目的对比
+
+2026 年 OSS memory 生态有 3 个其他主要项目, 潜在用户可能考虑:
+
+- **OpenHuman** (`tinyhumansai/openhuman`): Rust + Tauri desktop
+  assistant, 118+ 西方 SaaS 集成。
+- **MemPalace** (`MemPalace/mempalace`): Python dev tool, verbatim
+  存储 + benchmark 驱动的检索 (LongMemEval R@5 = 96.6 %)。
+- **ReMe** (`agentscope-ai/ReMe`): agent memory 管理 kit, AgentScope
+  生态出品。
+
+下面是"为什么选 memexa" 的诚实回答:
+
+| 能力 | OpenHuman | MemPalace | ReMe | **memexa** |
+|---|---|---|---|---|
+| 存储模式 | 3k-token markdown 层级摘要 | Verbatim 全文 + Zettelkasten 字面索引 | agent-context tool kit | **Verbatim 原始 + LLM 抽取 V2 envelope** |
+| 多人群聊角色解析 | summary 折掉说话人角色 | 无 role 概念 | agent 层 | ✅ V2 envelope `roles[]` + `identity_assertions` |
+| 每条断言可回溯原句 | summary 已折叠 | ✅ verbatim 直回 | agent 层 | ✅ `evidence_quotes` 把每条 claim 绑回原句 + `chunk_id` |
+| 跨别名 canonical id | 只到人名, 不抽别名 | 无 entity 概念 | agent 层 | ✅ `identity_manifest` + 4 阶段 0-LLM 算法 |
+| 中文相对时间解析 ("上周三") | 只看文档时间 | 无 | 无 | ✅ `time_resolutions` (ISO 8601 + 相对锚点) |
+| 抽取幻觉控制 | 无 — 单次摘要 | 无 — 不抽取 | 无 | ✅ 双 LLM gate + extract + DeepSeek arbiter 仲裁 |
+| 中文原生 IM 源 (微信 / QQ / 飞书 / 钉钉) | 无 (仅 Western OAuth) | 无 | 无 | ✅ 微信 + QQ 已 ship; 飞书 + 钉钉 在 v0.3 |
+
+论点很直接: 层级摘要 (OpenHuman) 必然丢信息; 字面 Zettelkasten
+(MemPalace) 无法在 10 人微信群聊里区分"谁对谁说"; agent-context kit
+(ReMe) 在另一个层级。memexa 同时保留 verbatim 原始 + LLM 抽取的结构化
+层 + 每条断言原文 citation, 并 ship 其他项目没理由建的中文 IM 摄入路径。
+
+## 为什么 memexa 是 agent-first 的, 以及这为什么重要
+
+对比表里没明说的第 2 个差异化: memexa 是名单里**唯一带有专门 agent
+协议文档**的项目。14 个子命令 + [`for_agents.zh.md`](for_agents.zh.md)
+的 7 条 hard rule 读起来像专门给 LLM 写的 API 契约 — 严格、密集、
+明确写出 agent 常踩的 6 个坑 (对人名调 topic / 外层并行包 topic·arc /
+把 pending 当语义召回 / 等)。
+
+为什么这点重要: **memexa 典型用户不是手敲命令的人**, 是代用户调
+memexa 的 AI agent (Claude Code / Cursor / Cline / 自写 agent)。
+CLI 表面和 agent 协议是同 14 个子命令; agent 读协议, 人读 usage guide,
+两者产出同样的调用。
+
+这也是 v0.2 **ship markdown workflow spec** (`docs/templates/weekly.md`
+等) 而**不是新增 CLI 子命令**的原因: agent 在运行时读 spec, 然后用
+已有的 14 个子命令 orchestrate。用户加自己的模板 = 复制一份
+markdown 文件, 不需要写 Python。
+
+## 术语表
+
+文档中反复出现的项目专属术语:
+
+- **Verbatim 原始 + V2 envelope**: 每条摄入消息原样保存; 旁边再放
+  一条独立的"V2 envelope" 记录, 装 LLM 抽取的结构化层 (narrative /
+  entities / evidence_quotes / time_resolutions / identity_assertions /
+  relation_assertions)。原始与抽取共存, 抽取永不替换原文。
+
+- **反流 (reflow)**: 把上游开发中 LIVE ≥ 4 周无回退的能力, 移植到
+  公开 memexa 仓。每次反流必先做 PII / 抽象 audit, 保证上游的真名 /
+  学校 / 私有路径不漏到 OSS。当前规划中 2 个主反流 milestone =
+  **中文 IM 反流 (v0.3)** 与 **音频 + 声纹反流 (v0.4)**。
+
+- **中文 IM 反流** (v0.3): 反流 QQ db-only 适配器 (SQLCipher 直读) /
+  本地文档源 (.md/.pdf/.docx/.txt + file-sha1 绑定) / Identity
+  manifest 自学习算法 / WeChat PC 备份摄入路径, 加 2 个全新 适配器
+  飞书 + 钉钉。目标: 中文 IM 覆盖从今日 WeChat+QQ 扩到 4 大主流 IM
+  平台 + 本地文档。
+
+- **音频 + 声纹反流** (v0.4): 反流 SenseVoice ASR 引擎 (中文 CER
+  ~6.8%, 5× realtime, 替换 Whisper) / 跨 session voice manifest
+  (基于 ECAPA 嵌入的 "自己 vs speaker N" 识别) / 多设备音频合并
+  (录音笔 + iPhone + 课堂口录, 按内容指纹去重)。目标: 中文音频成为
+  一等公民 source, 带说话人消歧, 不只是 transcript。
+
+- **Workflow spec** (v0.2): `docs/templates/` 下的 Markdown 文档,
+  描述 AI agent 应该如何 orchestrate 14 个查询子命令产出某个具体
+  deliverable (周报 / 会前 brief / 时段复盘)。spec 在运行时被 agent
+  读取 — ship 新 spec 不需要给 memexa 加 Python 代码。
+
+## 用户场景
+
+memexa 服务 5 类场景, 共用同一套底层 (ingestion + 抽取 + 图谱 + 查询),
+只在上层 deliverable 模板不同。
+
+| 场景 | 典型用户 | 主用 workflow (v0.2 +) |
+|---|---|---|
+| **知识工作者 / PM / 咨询** | 双语办公人士、自由职业 | `weekly` spec (跨源周报), `brief` spec (会前 brief, 针对人) |
+| **研究者 / 学生 / 学者** | 在校生、研究生 | `brief` spec (答辩 / talk 准备, 针对主题), `retro` spec (项目复盘, 按时段) |
+| **内容创作者 / 自媒体** | 公众号作者、知乎答主、小红书博主 | `retro` spec (灵感回收), v0.7 社区 spec 模板 |
+| **中小企业主 / 个体户** | 自由专业人士、小工作室主 | `brief` spec (客户 / 潜客准备), `retro` spec (交易复盘) |
+| **自我量化 / GTD / 隐私用户** | self-hosted 极客、GTD 实践者 | `memexa pending` 查询 (跨源待办), `retro` spec (周回顾) |
+
+5 个场景都是一级公民。v0.2 ship 3 个 workflow spec (`weekly` /
+`brief` / `retro`, 作为 `docs/templates/` 下的 markdown 文档) 覆盖
+5 场景的最常见需求。Agent 在运行时读 spec, 跑 14 个查询子命令中相关的
+那批, 合成带逐条 citation 的 Markdown 报告。v0.7 把同一套创作路径开
+放给用户 — 新模板 = 新 markdown 文件, 不写 Python。
+
+## V2 envelope 字段参考
+
+开发者如果想理解 extractor 实际产出什么, 每张抽取卡含以下字段:
+
+- `narrative`: 中文摘要, ≤ 200 字
+- `entities`: `{surface, kind, canonical_id?}` 列表; `kind` 是
+  `person` / `org` / `place` / `event` / `thing` 之一
+- `evidence_quotes`: 来自原文的句子列表, 用来证明 `narrative` 中的断言。
+  **每个 claim 必须有 ≥ 1 条 quote 支持**, 在抽取时强制
+- `time_resolutions`: `{surface, iso_start, iso_end?, anchor?}` 列表;
+  把相对时间 ("上周三下午"、"前天") 转成绝对 ISO 8601
+- `identity_assertions`: `{surface_a, surface_b, confidence}` 列表;
+  断言两个表面形式指向同一 canonical entity
+- `relation_assertions`: `{subject, predicate, object, evidence}` 列表;
+  抽取出的关系 ("Y 老师把 DDIA 第 5 章推荐给 Alice")
+- `roles[]`: 每条消息的说话人角色 (sender / mentioned / audience),
+  支持群聊说话人消歧
+- `salience`: 0.0 - 1.0 重要度评分; 低于默认 `0.4` 阈值的卡不进
+  `session-context` 注入
+- `chunk_id` + `source_origin`: 指回原始 batch JSON 文件, 用户随时能查
+  原始消息上下文
+
+上面的论点是真实的因为这些字段每张卡都填; citation 不是愿景, 是 tested
+invariant。

--- a/memexa/cli/main.py
+++ b/memexa/cli/main.py
@@ -302,6 +302,110 @@ def _cmd_query(args: argparse.Namespace, remainder: List[str]) -> int:
     return memory_query._cli(argv)
 
 
+def _cmd_demo(_args: argparse.Namespace) -> int:
+    """30-second onboarding: ingest the bundled synthetic dataset with the
+    stub extractor (no LLM key required), then run five example queries
+    against the resulting in-memory card set.
+
+    No Docker, no API key, no configuration. Designed to give a first-
+    time visitor a concrete sense of what the project does in well under
+    a minute on a clean Python install.
+    """
+    # 2026-05-16: demo output uses non-ASCII glyphs (✓, ─, ▸, en/em
+    # dashes, CJK). Windows console default is GBK which can't encode
+    # any of those. Force UTF-8 the same way memory_query._cli does.
+    try:
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    except Exception:
+        pass
+    print("memexa demo  —  thirty-second onboarding")
+    print("─" * 60)
+    print("[1/3] Ingesting the bundled synthetic dataset (stub extractor) ...")
+
+    try:
+        from examples.demo_dataset import ingest as demo_ingest  # type: ignore
+    except Exception as e:  # pragma: no cover — defensive
+        print(f"[fail] cannot import bundled demo dataset: {e}", file=sys.stderr)
+        print("       Ensure memexa was installed from a source distribution"
+              " that includes the examples/ tree, or clone the repo.",
+              file=sys.stderr)
+        return 1
+
+    cards: list[dict] = []
+    try:
+        for source_fn in (
+            demo_ingest.ingest_wechat,
+            demo_ingest.ingest_qq,
+            demo_ingest.ingest_email,
+            demo_ingest.ingest_browser,
+            demo_ingest.ingest_claude,
+            demo_ingest.ingest_audio,
+        ):
+            cards.extend(source_fn(stub=True))
+    except AttributeError:
+        # Older demo dataset module shape: call top-level ingest_all().
+        cards = demo_ingest.ingest_all(stub=True)  # type: ignore[attr-defined]
+
+    if not cards:
+        print("[fail] demo ingestion produced zero cards — bundle malformed.",
+              file=sys.stderr)
+        return 1
+
+    by_src: dict[str, int] = {}
+    for c in cards:
+        by_src[c.get("source", "?")] = by_src.get(c.get("source", "?"), 0) + 1
+    src_summary = ", ".join(f"{s}={n}" for s, n in sorted(by_src.items()))
+    print(f"      ✓ Ingested {len(cards)} cards across {len(by_src)}"
+          f" sources ({src_summary}).")
+    print()
+
+    print("[2/3] Running five sample queries against the in-memory set ...")
+    samples = [
+        ("quick", "Alice",
+         lambda kw: [c for c in cards
+                     if kw.lower() in c.get("narrative", "").lower()
+                     or kw.lower() in " ".join(
+                         e.get("surface", "") for e in c.get("entities", [])
+                     ).lower()][:3]),
+        ("arc", "Alice ↔ Bob",
+         lambda _kw: [c for c in cards
+                      if "Alice" in c.get("narrative", "")
+                      and "Bob" in c.get("narrative", "")][:3]),
+        ("timeline", "2024-01",
+         lambda _kw: sorted(
+             [c for c in cards if c.get("when_start", "").startswith("2024-01")],
+             key=lambda x: x.get("when_start", ""),
+         )[:3]),
+        ("pending", "(commitment cards)",
+         lambda _kw: [c for c in cards
+                      if "commitment" in c.get("types_csv", "")][:3]),
+        ("topic", "DDIA",
+         lambda kw: [c for c in cards
+                     if kw.lower() in c.get("narrative", "").lower()][:3]),
+    ]
+
+    for sub, term, fn in samples:
+        try:
+            hits = fn(term)
+        except Exception:  # pragma: no cover
+            hits = []
+        print(f"  ▸ memexa {sub} {term!r}")
+        if not hits:
+            print(f"     (0 cards — synthetic dataset; expected for some samples)")
+        for h in hits:
+            narr = h.get("narrative", "")[:90]
+            when = h.get("when_start", "?")[:10]
+            src = h.get("source", "?")
+            print(f"     [{src:<7s} {when}] {narr}")
+        print()
+
+    print("[3/3] Done.  Next steps:")
+    print("      • memexa init       — scaffold ~/.memexa/ config")
+    print("      • memexa doctor     — self-diagnostic against your backend")
+    print("      • docs/quickstart.md — Tier 1 (5 min) or Tier 2 (30 min)")
+    return 0
+
+
 def _build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
         prog="memexa",
@@ -339,6 +443,12 @@ def _build_parser() -> argparse.ArgumentParser:
 
     sp_doctor = sub.add_parser("doctor", help="self-diagnostic against backend")
     sp_doctor.set_defaults(func=_cmd_doctor)
+
+    sp_demo = sub.add_parser(
+        "demo",
+        help="30-second onboarding: ingest synthetic dataset + run 5 queries (no backend, no LLM key)",
+    )
+    sp_demo.set_defaults(func=_cmd_demo)
 
     # `memexa query <subcmd>` proxies to memory_query
     sp_query = sub.add_parser(

--- a/memexa/core/memory_query.py
+++ b/memexa/core/memory_query.py
@@ -1522,6 +1522,12 @@ def _cli(argv: List[str]) -> int:
     except Exception:
         pass
     p = argparse.ArgumentParser(prog="memexa.core.memory_query")
+    # 2026-05-16 v0.1.x: --json output mode lets AI agents (Claude Code,
+    # Cursor, Cline) parse memexa output via json.loads() instead of
+    # text. Subprocess CLI is the current first-class agent path;
+    # native MCP server lands in v0.5.
+    p.add_argument("--json", action="store_true",
+                   help="emit raw result as JSON array/object for agent parsing")
     sub = p.add_subparsers(dest="cmd", required=True)
 
     pq = sub.add_parser("quick")
@@ -1661,6 +1667,81 @@ def _cli(argv: List[str]) -> int:
     _ok = True
     _err: Optional[str] = None
     try:
+        # 2026-05-16 v0.1.x: --json mode short-circuits text rendering.
+        # Same call surface, raw return value as JSON to stdout. Agents
+        # invoking memexa via subprocess CLI should pass --json.
+        if args.json:
+            if args.cmd == "quick":
+                _res = quick(args.query, source=args.source, types=args.types,
+                             tier_in=args.tier, salience_min=args.salience,
+                             max_k=args.max_k, include_legacy=args.legacy)
+            elif args.cmd == "reflect":
+                _res = reflect(args.query, budget=args.budget,
+                               layers=("event",) if args.no_articles
+                                       else ("event", "article"))
+            elif args.cmd == "timeline":
+                _res = timeline((args.start, args.end), room=args.room,
+                                source=args.source)
+            elif args.cmd == "person":
+                _res = person(args.name)
+            elif args.cmd == "project":
+                _res = project(args.topic)
+            elif args.cmd == "pending":
+                _res = pending()
+            elif args.cmd == "session-context":
+                _res = session_start_context()
+            elif args.cmd == "arc":
+                _res = arc(args.entity, max_cards=args.max_cards,
+                           budget=args.budget,
+                           include_legacy=not args.no_legacy)
+            elif args.cmd == "topic":
+                _res = topic(args.topic, variants=args.variants,
+                             max_cards=args.max_cards,
+                             salience_min=args.salience,
+                             budget=args.budget,
+                             include_legacy=not args.no_legacy,
+                             chronological=not args.by_salience)
+            elif args.cmd == "types":
+                _res = types_query(args.filter, status=args.status,
+                                   source=args.source, days=args.days,
+                                   max_k=args.max_k,
+                                   salience_min=args.salience)
+            elif args.cmd == "graph-walk":
+                _res = graph_walk(args.entity, depth=args.depth,
+                                  max_per_hop=args.max_per_hop,
+                                  salience_min=args.salience)
+            elif args.cmd == "summary":
+                _res = summary(window_days=args.window_days,
+                               source=args.source,
+                               topic_hint=args.topic_hint,
+                               budget=args.budget)
+            elif args.cmd == "trends":
+                _res = trends(by=args.by, window_days=args.window_days,
+                              top_n=args.top_n,
+                              salience_min=args.salience)
+            elif args.cmd == "cross-source":
+                _res = cross_source(args.query, sources=args.sources,
+                                    max_per_source=args.max_per_source,
+                                    days=args.days)
+            else:
+                _res = {"error": f"unknown subcommand: {args.cmd}"}
+            # Count for the query log (best-effort across heterogeneous
+            # return shapes).
+            if isinstance(_res, list):
+                _n_results = len(_res)
+            elif isinstance(_res, dict):
+                _n_results = (
+                    len(_res.get("recent_events") or [])
+                    or len(_res.get("hops") or [])
+                    or len(_res.get("top") or [])
+                    or sum(len(v) for v in (_res.get("by_source") or {}).values()
+                           if isinstance(v, list))
+                    or (1 if _res.get("text") else 0)
+                )
+            print(json.dumps(_res, ensure_ascii=False, default=str))
+            return 0
+        # Below: original text-rendering path, unchanged when --json
+        # is not set.
         if args.cmd == "quick":
             res = quick(args.query, source=args.source, types=args.types,
                          tier_in=args.tier, salience_min=args.salience,

--- a/tests/integration/test_demo_subcommand.py
+++ b/tests/integration/test_demo_subcommand.py
@@ -1,0 +1,74 @@
+"""Integration test for ``memexa demo`` subcommand.
+
+Verifies the 30-second onboarding path end-to-end:
+
+  - ``memexa demo`` returns rc=0
+  - stdout reports ≥ 1 card across the six bundled sources
+  - five query labels appear in stdout (quick / arc / timeline /
+    pending / topic)
+  - no backend, no LLM key, no configuration required (the test
+    process clears any MEMEXA_* env that might point at one)
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+from memexa.cli.main import main
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture(autouse=True)
+def _clear_memexa_env(monkeypatch):
+    """Demo command must work even when the user has no backend env set."""
+    for k in list(os.environ):
+        if k.startswith("MEMEXA_"):
+            monkeypatch.delenv(k, raising=False)
+
+
+def test_demo_returns_zero_and_prints_card_count(capsys):
+    rc = main(["demo"])
+    captured = capsys.readouterr()
+    assert rc == 0, f"memexa demo returned rc={rc}; stdout:\n{captured.out}\nstderr:\n{captured.err}"
+    assert "Ingested" in captured.out
+    # The bundled synthetic dataset across six sources is small but
+    # never empty.
+    assert "0 cards" not in captured.out or "✓ Ingested" in captured.out
+
+
+def test_demo_runs_five_sample_queries(capsys):
+    rc = main(["demo"])
+    captured = capsys.readouterr()
+    assert rc == 0
+    for label in ("memexa quick", "memexa arc", "memexa timeline",
+                  "memexa pending", "memexa topic"):
+        assert label in captured.out, (
+            f"expected sample query label {label!r} in demo stdout but"
+            f" did not find it; full stdout:\n{captured.out}"
+        )
+
+
+def test_demo_prints_next_steps(capsys):
+    """Demo must hand the user off to the next path (init / doctor /
+    quickstart docs)."""
+    rc = main(["demo"])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "memexa init" in captured.out
+    assert "memexa doctor" in captured.out
+    assert "quickstart" in captured.out.lower()
+
+
+def test_demo_help_lists_subcommand(capsys):
+    """``memexa --help`` (no args) should advertise the demo subcommand
+    so a first-time user discovers it without reading docs."""
+    rc = main([])
+    captured = capsys.readouterr()
+    # `main([])` prints help; rc should be 0 (friendly hint mode).
+    assert rc == 0
+    # The argparse-generated help lists registered subcommands; demo
+    # must appear there.
+    assert "demo" in captured.out

--- a/tests/integration/test_subcmd_json_output.py
+++ b/tests/integration/test_subcmd_json_output.py
@@ -1,0 +1,88 @@
+"""Integration test for the ``--json`` output mode added in v0.1.x.
+
+The fourteen query subcommands all accept ``--json`` at the top level
+of ``python -m memexa.core.memory_query``. When set, the subcommand
+short-circuits text rendering and emits a single JSON document on
+stdout that an AI agent can parse with ``json.loads()``.
+
+These tests verify:
+
+1. The ``--json`` flag is accepted by the argparse top-level parser.
+2. Subcommands that don't require a running Hindsight backend
+   (``pending``, ``session-context``) emit valid JSON and exit cleanly.
+3. The query log records the invocation just like the text path does.
+4. Help text exposes ``--json`` so a first-time agent reader sees it.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+PY = [sys.executable, "-m", "memexa.core.memory_query"]
+
+
+def _run(args, timeout=10):
+    """Invoke the memory_query CLI as a subprocess; return (rc, stdout, stderr).
+
+    Force UTF-8 decoding because the memexa CLI uses Chinese characters
+    that don't round-trip through Windows GBK.
+    """
+    proc = subprocess.run(PY + args, capture_output=True,
+                          encoding="utf-8", errors="replace",
+                          timeout=timeout)
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def test_json_flag_appears_in_top_level_help():
+    rc, out, err = _run(["--help"])
+    assert rc == 0
+    assert "--json" in out, (
+        "expected --json to be listed in top-level help; got:\n" + out
+    )
+
+
+def test_pending_json_returns_parseable_list():
+    """`pending` is the simplest subcommand for this test because it does
+    not require a Hindsight backend — it reads the calendar index off
+    disk and emits commitment cards."""
+    rc, out, err = _run(["--json", "pending"])
+    assert rc == 0, f"--json pending exit rc={rc}; stderr:\n{err}"
+    # stdout must be parseable as JSON.
+    parsed = json.loads(out.strip().splitlines()[0])
+    # Either a list (active commitments) or an empty list (none).
+    assert isinstance(parsed, list), (
+        f"--json pending should emit a JSON array; got {type(parsed).__name__}"
+    )
+
+
+def test_pending_json_does_not_print_human_text():
+    """The JSON path must short-circuit the text renderer. No 'PENDING ('
+    header should appear in --json output."""
+    rc, out, err = _run(["--json", "pending"])
+    assert rc == 0
+    assert "PENDING (" not in out, (
+        f"--json mode should suppress human text headers; saw 'PENDING ('"
+        f" in stdout:\n{out}"
+    )
+
+
+def test_subcommands_accept_json_flag_without_argparse_error():
+    """For every advertised subcommand, ``--json <subcmd> --help`` should
+    parse cleanly (rc=0 from argparse). This proves the flag is wired
+    at top level, not duplicated per subcommand."""
+    subcmds = [
+        "quick", "reflect", "timeline", "person", "project", "pending",
+        "session-context", "topic", "arc", "types", "graph-walk",
+        "summary", "trends", "cross-source",
+    ]
+    for sc in subcmds:
+        rc, out, err = _run(["--json", sc, "--help"])
+        # argparse exit 0 on --help, regardless of subcmd
+        assert rc == 0, (
+            f"argparse rejected '--json {sc} --help'; rc={rc}, stderr:\n{err}"
+        )


### PR DESCRIPTION
## Summary

Prepares v0.1.0-rc3 with three orthogonal improvements that close out
the first-experience path for both humans and AI agents.

**Project positioning clarified as agent backbone**: the primary user
is an AI agent (Claude Code, Cursor, Cline) invoking memexa as a
subprocess on a human user's behalf. Direct CLI use by a human is
also supported but secondary.

## What's in

### New features (code)

| Feature | File | Why |
|---|---|---|
| `memexa demo` subcommand | `memexa/cli/main.py` | 30-second onboarding (`pip install` → `memexa demo` → 5 query results in terminal). No Docker, no LLM key, no config. The Tier-0 first-time visitor path. |
| `--json` output mode for all 14 query subcommands | `memexa/core/memory_query.py` | First-class agent integration via subprocess. Top-level flag short-circuits text rendering; emits raw return value as JSON. |

### New docs (4 new files, double-language)

- `docs/why.md` / `why.zh.md` — per-capability comparison vs OpenHuman / MemPalace / ReMe, agent-first design rationale, glossary covering V2 envelope / reflow / Chinese-IM reflow / audio + voice reflow / workflow spec terms.
- `docs/cost.md` / `cost.zh.md` — API call volume and monthly cost estimates for DeepSeek V4 Flash/Pro, GPT-4o, Claude 4.x. Recommended Flash-gate + Pro-extract combination at **¥0.30 per 1 000 messages**.

### Brand and roadmap consolidation

- **README first screen** restored: positioning line + 🤖 AI-agent compatible paragraph + dual Quickstart (humans `memexa demo`, agents `memexa quick "X" --json`).
- **`docs/quickstart.md` Tier 0 dual paths** — humans run `memexa demo`, agents call subcommands with `--json`. Tier 1 / 2 unchanged.
- **`ROADMAP.md` v0.2 redefined** from \"Python deliverable code + CLI subcommands\" to **Markdown workflow specs** under `docs/templates/`. Agents read specs at runtime; users author their own by copying a markdown file. v0.5 promotes subprocess to native MCP server. v0.7 formalises user-authored specs. New v0.8+ section for optional desktop GUI exploration.
- **`Makefile`** lint / format targets corrected to `memexa tests` (residue from PR #9 src→memexa rename).
- **`CHANGELOG.md`** Unreleased section rewritten with full breakdown.

### Tests (2 new files, 8 tests)

- `tests/integration/test_demo_subcommand.py` — 4 tests: rc=0, prints card count, runs 5 sample queries, lists demo in help.
- `tests/integration/test_subcmd_json_output.py` — 4 tests: \`--json\` in top-level help, returns valid JSON, suppresses text output, all 14 subcmds accept the flag.

## Test plan (local verification)

- [x] **pytest**: 58 passed / 2 pre-existing skips (prompt drift, unrelated to this PR)
- [x] **PII scan**: 0 matches
- [x] **ast.parse**: 4/4 changed Python files clean
- [x] **\`memexa demo\` rc=0** on Windows with UTF-8 stdout reconfigure
- [x] **\`memexa --json pending\` returns parseable JSON**
- [x] **Makefile lint paths**: corrected to `memexa tests`
- [x] **Brand consistency audit**: 0 \"memexa weekly/brief/retro\" CLI references in public docs (v0.2 redefined to spec docs); 0 \"#1 in China\" / \"国内第一\" in public docs
- [ ] **CI auto** — expecting all 18 checks green: Lint / Tests × 9 matrix / Bandit / gitleaks / pip-audit / Demo dataset / PII / CodeQL / Package build

## Stats

```
 CHANGELOG.md                | 132 ++++++++++--
 Makefile                    |  10 +-
 README.md                   | 335 ++++++++++--------------------
 README.zh.md                | 315 +++++++++-------------------
 ROADMAP.md                  | 489 +++++++++++++++++++-------------------------
 ROADMAP.zh.md               | 435 ++++++++++++++++-----------------------
 docs/cost.md                | 150 +++++++++++++ (new)
 docs/cost.zh.md             | 140 +++++++++++++ (new)
 docs/quickstart.md          | 296 +++++++++++++++++++--------
 docs/quickstart.zh.md       | 275 +++++++++++++++++--------
 docs/why.md                 | 250 +++++++++++++++++++++ (new)
 docs/why.zh.md              | 240 +++++++++++++++++++++ (new)
 memexa/cli/main.py          | 110 ++++++++++
 memexa/core/memory_query.py |  81 ++++++++
 tests/integration/test_demo_subcommand.py    |  80 ++++++++ (new)
 tests/integration/test_subcmd_json_output.py |  90 ++++++++ (new)

 16 files changed, 1994 insertions(+), 1177 deletions(-)
```

## Not in this PR (deferred to later milestones)

- **v0.2 deliverable spec documents** (`docs/templates/*`) — ship in v0.2 milestone.
- **memexa-mcp MCP server** — ships in v0.5.
- **Internal execution plan and video promo schedule** — lives in `.audit/EXECUTION_PLAN.md`, gitignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)