### PR TITLE
fix(release): bundle demo dataset in wheel + dynamic __version__ (rc4)

### DIFF
--- a/memexa/__init__.py
+++ b/memexa/__init__.py
@@ -1,4 +1,16 @@
 """memexa — self-hosted Chinese personal memory graph."""
 
-__version__ = "0.1.0a0"
+# 2026-05-16 rc4: read version dynamically from the installed package
+# metadata so this file never drifts out of sync with pyproject.toml.
+# Hard-coding bit rc1/rc2/rc3 — all four releases shipped with
+# memexa.__version__ still reading "0.1.0a0".
+try:
+    from importlib.metadata import version as _version, PackageNotFoundError as _PNE
+    try:
+        __version__ = _version("memexa")
+    except _PNE:
+        __version__ = "0.0.0+unknown"
+except Exception:
+    __version__ = "0.0.0+unknown"
+
 __all__ = ["__version__"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "memexa"
-version = "0.1.0rc3"
+version = "0.1.0rc4"
 description = "镜我 · Your personal Pensieve. Turn scattered Chinese data into ready-to-use deliverables."
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -99,8 +99,19 @@ package-dir = { "" = "." }
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["memexa*"]
-exclude = ["tests*", "examples*", ".audit*"]
+# 2026-05-16 rc4: include examples.demo_dataset* so `memexa demo`
+# subcommand can `from examples.demo_dataset import ingest` after a
+# fresh PyPI install. rc3 wheel excluded examples and `memexa demo`
+# failed with ModuleNotFoundError. The other examples/ subtrees
+# (walkthroughs, agent_integrations, etc.) remain excluded because
+# they are docs/scripts not import targets.
+include = ["memexa*", "examples", "examples.demo_dataset", "examples.demo_dataset.*"]
+exclude = ["tests*", "examples.community_templates*", ".audit*"]
+
+[tool.setuptools.package-data]
+# Ship the bundled synthetic dataset's JSON / JSONL data files inside
+# the wheel so `memexa demo` works without a source checkout.
+"examples.demo_dataset" = ["*.json", "*.jsonl", "*.md"]
 
 [tool.ruff]
 line-length = 100


### PR DESCRIPTION
## Summary

rc3 (PyPI 2026-05-16 14:22 UTC) had two release-blocker bugs caught only by fresh-venv install verification:

| Bug | Root cause | User-visible failure |
|---|---|---|
| 1. \`memexa demo\` ImportError | \`pyproject.toml\` excluded \`examples*\` from the wheel — \`examples/demo_dataset/\` (the data + import target for \`_cmd_demo\`) was dropped | \`memexa demo\` after fresh \`pip install --pre memexa==0.1.0rc3\` fails with \`No module named 'examples.demo_dataset'\` |
| 2. \`memexa version\` returned \`0.1.0a0\` | \`memexa/__init__.py\` had \`__version__\` hard-coded; four releases (a0/rc1/rc2/rc3) shipped without bumping it | Users see the wrong version |

## Fixes (this PR)

### \`pyproject.toml\`

Include \`examples.demo_dataset\` in the wheel via \`packages.find\` + ship JSON/JSONL data files via \`package-data\`. Other \`examples/*\` subtrees (walkthroughs, agent_integrations, community_templates) stay excluded — they are docs/scripts, not import targets.

\`\`\`toml
include = [\"memexa*\", \"examples\", \"examples.demo_dataset\", \"examples.demo_dataset.*\"]
exclude = [\"tests*\", \"examples.community_templates*\", \".audit*\"]

[tool.setuptools.package-data]
\"examples.demo_dataset\" = [\"*.json\", \"*.jsonl\", \"*.md\"]
\`\`\`

### \`memexa/__init__.py\`

Read version dynamically from installed-package metadata so it cannot drift again:

\`\`\`python
from importlib.metadata import version as _version, PackageNotFoundError as _PNE
try:
    __version__ = _version(\"memexa\")
except _PNE:
    __version__ = \"0.0.0+unknown\"
\`\`\`

### \`pyproject.toml\` version bump

\`0.1.0rc3\` → \`0.1.0rc4\`. (PyPI does not allow re-publishing the same version number.)

### Internal: new pre-flight checklist Item 7

\`.audit/MAINTENANCE_PROTOCOL.md §4.1\` adds:

\`\`\`
□ 7. Fresh venv install built wheel + run demo + run version
\`\`\`

This is the only step that catches packaging-layer bugs like the two in rc3, because CI \`pip install -e .[dev]\` editable mode links \`examples/\` from the source tree and hides the wheel-only \`packages.find\` exclude problem.

## Verification (7-item pre-flight checklist all PASS)

| # | Item | Result |
|---|---|---|
| 1 | pyproject.toml version == 0.1.0rc4 | ✓ |
| 2 | CHANGELOG.md Unreleased has rc4 context | ✓ |
| 3 | publish.yml release-trigger LIVE | ✓ |
| 4 | \`python -m build\` → \`memexa-0.1.0rc4.tar.gz\` + \`.whl\` | ✓ |
| 4b | wheel contains \`examples/demo_dataset/{ingest.py, *.json, *.jsonl}\` | ✓ (verified via \`unzip -l\`) |
| 5 | main CI last 4 push runs all SUCCESS | ✓ |
| 6 | local pytest 8/8 demo + json tests PASS | ✓ |
| 7 | **Fresh Python 3.11 venv + \`pip install dist/memexa-0.1.0rc4-py3-none-any.whl\`**: | ✓ |
|   | \`memexa demo\` → rc=0, 26 cards ingested, 5 query labels printed | ✓ |
|   | \`memexa version\` → \"memexa 0.1.0rc4\" (was \"0.1.0a0\" in rc3) | ✓ |
|   | \`memexa --json pending\` → \"[]\" valid JSON | ✓ |

## rc3 disposition

PyPI does not allow delete or republish. After rc4 lands:

- \`pip install --pre memexa\` → resolves to rc4 (higher version)
- \`pip install --pre memexa==0.1.0rc3\` → still installs rc3 (broken \`memexa demo\`)
- rc3 release page remains on GitHub as a historical record of the failure

Not explicitly yanking rc3 — superseding cleanly by rc4 leaves less visible disruption than yank's \"yanked release\" badge.

## Test plan

- [x] Local 7-item pre-flight (above)
- [ ] CI: 18/19 checks green
- [ ] After merge: \`gh release create v0.1.0-rc4\` triggers publish.yml
- [ ] After PyPI CDN sync: end-to-end fresh-venv test of PyPI-installed rc4 matches local wheel test

🤖 Generated with [Claude Code](https://claude.com/claude-code)