### PR TITLE
chore(changelog): post-v0.1.1 publish tidy — [Unreleased] + PyPI link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-(Nothing yet — `0.1.1` was the latest cut.)
+Tracking against v0.1.2. Known v0.1.1 gaps queued here:
+
+- Other IMAP providers (Gmail / Outlook / iCloud / 163 / 126 / Yeah /
+  Hotmail / Sina / Live) — wizards have correct host/port/auth hints
+  but only QQ + USTC have been LIVE-fetched in v0.1.1.
+- Large-volume ingest (>500 batches) — small dataset proven; scale
+  not yet stress-tested.
+- WeChatMsg-from-the-real-binary — adapter reverse-engineered from
+  documented schema; real WeChatMsg.exe output not in v0.1.1
+  verification.
+- Hindsight async-consolidation transparency — `memexa ingest` shows
+  `dead-letter: N` when verify-after-POST sees `total=0`, but cards
+  are usually in the document store waiting for the background
+  consolidator. v0.1.2 should auto-trigger `/consolidate`.
 
 ## [0.1.1] — 2026-05-17
+
+Published to PyPI 2026-05-17 15:20:59 UTC.
+[pypi.org/project/memexa/0.1.1/](https://pypi.org/project/memexa/0.1.1/)
 
 Onboarding rewrite + critical fix for the email path that v0.1.0
 unintentionally shipped broken.

--- a/CHANGELOG.zh.md
+++ b/CHANGELOG.zh.md
@@ -9,9 +9,23 @@
 
 ## [Unreleased]
 
-(暂无 — `0.1.1` 是最新一切。)
+针对 v0.1.2 跟踪。已知 v0.1.1 留尾排在这里：
+
+- 其他 IMAP provider (Gmail / Outlook / iCloud / 163 / 126 / Yeah /
+  Hotmail / Sina / Live) —— wizard 有正确 host/port/auth 提示但
+  v0.1.1 只 LIVE-fetched 过 QQ + USTC。
+- 大批量 ingest (>500 batches) —— 小数据集验证过，规模未压测。
+- WeChatMsg 真二进制导出 —— adapter 是基于公开 schema 反向工程的，
+  真实 WeChatMsg.exe 输出未在 v0.1.1 内验证。
+- Hindsight async-consolidation 透明化 —— `memexa ingest` 在
+  verify-after-POST 看到 `total=0` 时报 `dead-letter: N`，但卡片
+  通常已经入了 document store 在等后台 consolidator。v0.1.2 应
+  自动触发 `/consolidate`。
 
 ## [0.1.1] — 2026-05-17
+
+发布到 PyPI 时间 2026-05-17 15:20:59 UTC.
+[pypi.org/project/memexa/0.1.1/](https://pypi.org/project/memexa/0.1.1/)
 
 Onboarding 重写 + 修复 v0.1.0 意外 ship 的 email broken path。
 


### PR DESCRIPTION
Post-publish changelog hygiene after v0.1.1 went live on PyPI today (2026-05-17 15:20:59 UTC).

## Changes

- `[Unreleased]` section refilled with v0.1.2 candidate items — the four known v0.1.1 gaps documented in the release notes:
  - Other IMAP providers (Gmail / Outlook / iCloud / 163 / 126 / Yeah / Hotmail / Sina / Live) need LIVE-fetch coverage
  - Large-volume ingest (>500 batches) stress test
  - WeChatMsg from the real binary
  - Hindsight async-consolidation transparency
- `[0.1.1]` entry annotated with the actual PyPI publish timestamp and direct project-page link

EN + ZH kept in sync.

## Why a PR (not a direct push to main)

Per repo policy (per `CONTRIBUTING.md` PR workflow SOP) — even maintainer-only docs hygiene goes through PR + CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)