### PR TITLE
docs(roadmap, quickstart): post-v0.1.1 — bump v0.1.0 → v0.1.1 + stage v0.1.2

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -90,23 +90,65 @@ Not yet shipped:
 ## v0.1.x — close out to stable
 
 The remaining v0.1 work unblocks the first-experience path for both
-**human users** and **AI agents**. v0.1.0 is cut from a green rc only
-after every item in this list is true.
+**human users** and **AI agents**.
 
-- `memexa demo` subcommand: a thirty-second walkthrough that uses the
-  bundled synthetic dataset and the stub extractor. No Docker, no LLM
-  key, no configuration.
-- `--json` output mode for all fourteen query subcommands, so agents
-  invoking memexa via shell can `json.loads()` the result directly
-  instead of parsing text. The subprocess-CLI path is the current
-  first-class agent integration; native MCP server arrives in v0.5.
-- `Makefile` lint and format targets point at `memexa tests` rather
-  than the deprecated `src` path.
-- `CHANGELOG.md` known-limitation about PyPI availability removed
-  (the package has been on PyPI since rc1).
-- At least one non-author issue, discussion, or pull request landed.
-- At least one full week elapsed since the most recent critical bug
-  fix.
+### v0.1.0 (shipped 2026-05-17)
+
+Stable cut from a green rc. All initial-experience gates were
+satisfied (`memexa demo` subcommand, fourteen-subcommand `--json`
+mode, Makefile lint/format targets, CHANGELOG cleanup, fresh-clone
+smoke test across Win + macOS + Linux × Python 3.10 / 3.11 / 3.12).
+
+### v0.1.1 (shipped 2026-05-17)
+
+Same-day follow-up. Fixed the v0.1.0 email path (hard-coded
+maintainer account names tried to import non-existent modules) and
+rewrote onboarding around three interactive wizards
+(`memexa init llm` / `init email` / `init wechat`) plus five new
+top-level commands (`memexa backend up/down/status` + `ingest
+email` + `ingest wechat`). A second pass replayed the whole flow
+as a brand-new user across Win 11 + Mac Studio + USTC Linux with
+real IMAP credentials and real WeChatMsg-schema JSON; this
+surfaced 13 more blockers, all fixed. 140 pytest pass. See
+[CHANGELOG.md `[0.1.1]`](CHANGELOG.md) for the full list.
+
+### v0.1.2 — next (in progress)
+
+Close the four LIVE-attestation gaps that v0.1.1's verification
+pass deferred. None of these are blockers for the "install →
+demo → init → ingest → query" flow on QQ / USTC IMAP / WeChat
+demo data, but each closes a credibility surface for early users.
+
+- **Other IMAP providers** (Gmail, Outlook, iCloud, 163, 126,
+  Yeah, Hotmail, Sina, Live). The `_detect_provider` table has
+  host / port / auth-type hints for each but only QQ and USTC
+  were LIVE-fetched in v0.1.1. v0.1.2 should produce at least one
+  LIVE-attested ingest run per provider (`fetched > 0`,
+  `errors == 0`) and add the provider to the integration matrix.
+- **Hindsight async-consolidation transparency.** `memexa ingest`
+  currently reports `dead-letter: N` when the post-POST verify
+  sees `total = 0`, even though the cards are in the document
+  store waiting for the background consolidator. v0.1.2 should
+  auto-`POST /consolidate` after ingest and either poll briefly
+  for completion or print "indexing in background, queryable in
+  ≤60s" so the user does not read a successful ingest as a
+  failure.
+- **Large-volume ingest (>500 batches).** v0.1.1 LIVE proved a
+  small dataset (≤20 batches). v0.1.2 should stress-test
+  rate-limit back-pressure, dead-letter recovery, memory
+  footprint, and (separately) document the empirically-correct
+  `--max-per-folder` and concurrency knobs.
+- **WeChatMsg-from-the-real-binary.** v0.1.1 adapter is
+  reverse-engineered from documented field names; a real
+  WeChatMsg release export was not in the verification pass.
+  v0.1.2 should drive at least one real WeChatMsg export through
+  the pipeline end-to-end and patch any field-name surprises.
+
+Optional, queued behind the four above if cycles permit:
+
+- One non-maintainer issue, discussion, or PR (community-health
+  signal — leftover from the v0.1.0 gate, still not met).
+- One full week without a critical bug fix on `main`.
 
 ## v0.2 — agent workflow templates
 

--- a/ROADMAP.zh.md
+++ b/ROADMAP.zh.md
@@ -75,18 +75,53 @@ v0.1.1 闭合 (原 v0.1.0 limitation):
 ## v0.1.x — 收尾 stable
 
 剩下的 v0.1 工作 = 同时打通**人类用户**和 **AI agent** 的第一体验路径。
-v0.1.0 仅在以下所有条件全部为真时, 才从绿色 rc 中切版本。
 
-- `memexa demo` 子命令: 30 秒 walkthrough, 用 bundled synthetic 数据
-  + stub extractor。无需 Docker, 无需 LLM key, 无需配置。
-- 14 个查询子命令全部加 `--json` 输出 mode, 让 agent 通过 shell 调
-  memexa 时能直接 `json.loads()`, 不用 parse 文本。subprocess CLI 路径
-  是当前 first-class agent integration; native MCP server 留 v0.5。
-- `Makefile` 的 lint / format target 指向 `memexa tests`（而不是已废
-  弃的 `src` 路径）。
-- `CHANGELOG.md` 删除"PyPI 尚未上"那条 known-limitation（rc1 起已 LIVE）。
-- 至少 1 个非作者的 issue / discussion / pull request 已 land。
-- 自最近一个 critical bug fix 起至少经过 1 周。
+### v0.1.0 (2026-05-17 已发布)
+
+从绿色 rc 切出的 stable 版本。所有首体验 gate 全过 (`memexa demo`
+子命令 / 14 个 subcmd `--json` mode / Makefile lint/format target /
+CHANGELOG 清理 / Win + macOS + Linux × Python 3.10 / 3.11 / 3.12
+全 fresh-clone smoke test)。
+
+### v0.1.1 (2026-05-17 同日发布)
+
+同日补发版本。修复 v0.1.0 邮件路径 (hard-coded 到不存在的 module) 并
+围绕 3 个交互式 wizard 重写 onboarding (`memexa init llm` /
+`init email` / `init wechat`), 加 5 个新顶层命令
+(`memexa backend up/down/status` + `ingest email` + `ingest wechat`)。
+第二轮按"全新用户"视角在 Win 11 + Mac Studio + USTC Linux 复测, 接
+真 IMAP 凭据 + 真 WeChatMsg-schema JSON, 浮出 13 个 fresh-user
+blocker, 全部修。140 pytest pass。详 [CHANGELOG.md `[0.1.1]`](CHANGELOG.zh.md)。
+
+### v0.1.2 — next (进行中)
+
+关掉 v0.1.1 验证延后的 4 个 LIVE-attestation gap。这些都**不阻塞**
+"install → demo → init → ingest → query" 走 QQ / USTC IMAP / 微信
+demo 数据的主流程, 但每一项都关掉一个 early user 的信任表面。
+
+- **其他 IMAP provider** (Gmail / Outlook / iCloud / 163 / 126 /
+  Yeah / Hotmail / Sina / Live)。`_detect_provider` 表里 host /
+  port / 鉴权提示都有, 但 v0.1.1 只 LIVE-fetched 过 QQ 和 USTC。
+  v0.1.2 应该每个 provider 至少跑过 1 次 LIVE 验证
+  (`fetched > 0`, `errors == 0`) 并加进 integration matrix。
+- **Hindsight 异步 consolidation 透明化**。`memexa ingest` 现在
+  POST-后-verify 看到 `total=0` 就报 `dead-letter: N`, 即使卡片
+  其实在 document store 等后台 consolidator。v0.1.2 应该 ingest
+  完自动 `POST /consolidate` + 短轮询 / 或打"后台索引中, ≤60s
+  可查询", 让用户不把成功的 ingest 当失败。
+- **大批量 ingest (>500 batches)**。v0.1.1 只验了小数据集
+  (≤20 batches)。v0.1.2 应该压测 rate-limit 回压 / dead-letter
+  恢复 / 内存 footprint, 并 (单独) 给出 `--max-per-folder` 和
+  concurrency 的实证推荐值。
+- **WeChatMsg 真实二进制导出**。v0.1.1 adapter 基于公开字段反向
+  工程; 真实 WeChatMsg release 导出未在验证范围。v0.1.2 应该
+  端到端跑一次真 WeChatMsg 导出 + 修任何字段名意外。
+
+可选, 时间允许才做:
+
+- 至少 1 个非维护者的 issue / discussion / PR (社区健康信号 —
+  v0.1.0 gate 残留, 仍未满足)。
+- main 上自最近 critical bug fix 起至少 1 周无新 critical fix。
 
 ## v0.2 — agent workflow 模板 (spec 文档, 非 Python 代码)
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -307,19 +307,19 @@ does not export data from any closed platform itself — it consumes
 exports produced by upstream tools, then normalises / extracts /
 indexes them.
 
-The table below is the honest per-source status as of `0.1.0`. ✅
+The table below is the honest per-source status as of `0.1.1`. ✅
 means an OSS-only path works end-to-end; ⚠ means it works but
 requires a third-party export tool or manual file move; ❌ means
 there is no recommended OSS path today and you must wait for the
 listed milestone.
 
-| Source         | OS path that works     | Today (v0.1.0)                                                                                       | When better                              |
+| Source         | OS path that works     | Today (v0.1.1)                                                                                       | When better                              |
 |----------------|------------------------|------------------------------------------------------------------------------------------------------|------------------------------------------|
-| **Email**      | Win / macOS / Linux    | ✅ `memexa init email` wizard (v0.1.1) — 6 providers auto-detected (gmail/outlook/icloud/qq/163/foxmail/ustc), 10 min total | —                                        |
+| **Email**      | Win / macOS / Linux    | ✅ `memexa init email` wizard — 12+ providers auto-detected (gmail / googlemail / outlook / hotmail / live / icloud / qq / foxmail / 163 / 126 / yeah / sina / mail.ustc); LIVE-attested on QQ + USTC IMAP in v0.1.1, other providers should work via the same code path. | —                                        |
 | **Audio**      | Win / macOS / Linux    | ✅ recorder export → Whisper / SenseVoice → JSON → builder                                            | v0.4 (cross-device merge, ECAPA enroll)  |
 | **Browser**    | Win / macOS / Linux    | ✅ read Chrome / Firefox SQLite history → builder                                                     | —                                        |
 | **Claude Code**| Win / macOS / Linux    | ✅ read `~/.claude/projects/*/conversations.jsonl` → builder                                          | —                                        |
-| **WeChat**     | **Windows only**       | ✅ `memexa init wechat` wizard (v0.1.1) wraps [WeChatMsg](https://github.com/LC044/WeChatMsg) — detects existing install or points at release page; you export in WeChatMsg, then `memexa ingest wechat`. macOS / Linux users still have no path (upstream tooling Windows-only). | v0.2+ (auto-download + GUI hand-off) |
+| **WeChat**     | **Windows only**       | ✅ `memexa init wechat` wizard wraps [WeChatMsg](https://github.com/LC044/WeChatMsg) — detects existing install or points at release page; you export in WeChatMsg, then `memexa ingest wechat`. v0.1.1 handles **6 message types** (text / image / sticker / video / appmsg-with-title / system-msg) so non-text content survives instead of being dropped. macOS / Linux users still have no path (upstream tooling Windows-only). | v0.2+ (auto-download + GUI hand-off) |
 | **QQ**         | Win / macOS / Linux    | ⚠ **db-only adapter not yet in OSS**. NapCat / OneBot path is **disabled by default** (Tencent fingerprint-bans accounts that ever ran NapCat — see [`integrations/qq.md`](integrations/qq.md)). To use the db-only path today, manually copy `jarvis/qq_db.py` from the upstream JARVIS repo (762 lines, stdlib only) into `memexa/extraction/qq/`. Clipboard fallback also lives upstream and has not been migrated. | v0.2 (db-only adapter + clipboard fallback migrated; NapCat path removed) |
 
 ### Recommended first-day order
@@ -335,7 +335,7 @@ listed milestone.
 5. **QQ** — only if you are willing to wire in the upstream
    `qq_db.py` manually. Otherwise wait for v0.2.
 
-### Known limitations of v0.1.0
+### Known limitations of v0.1.1
 
 - **QQ db-only adapter** is not yet in the OSS package; the reference
   implementation lives in upstream JARVIS as a single 762-line
@@ -345,6 +345,20 @@ listed milestone.
   Windows-only. macOS / Linux users have a deployment guide but no
   WeChat-history path. Tracked in v0.3 (WeChat PC backup ingestion)
   but ultimately bounded by upstream tool availability.
+- **Other IMAP providers** (Gmail / Outlook / iCloud / 163 / 126 /
+  Yeah / Hotmail / Sina / Live) — the wizard has correct host /
+  port / auth hints for each but only QQ and USTC have been LIVE-
+  fetched in v0.1.1 verification. v0.1.2 will close the LIVE
+  attestation gap.
+- **Hindsight async-consolidation transparency** — `memexa ingest`
+  shows `dead-letter: N` when its post-POST verify sees `total=0`,
+  but the cards are usually already in the document store waiting
+  for the background consolidator. v0.1.2 will auto-trigger
+  `/consolidate` after ingest.
+- **WeChatMsg field-name coverage** — the schema adapter is
+  reverse-engineered from documented fields; truly novel field
+  names emitted by future WeChatMsg releases may need a v0.1.2
+  patch.
 - **No 飞书 / 钉钉 adapter** — v0.3.
 - **No local-document source** (`.md` / `.pdf` / `.docx` / `.txt`) —
   v0.3.

--- a/docs/quickstart.zh.md
+++ b/docs/quickstart.zh.md
@@ -284,17 +284,17 @@ Tier 0 / 1 / 2 验证的是**管线**: package 装上、backend 起来、合成
 不导出任何闭源平台的数据** — 它消费上游工具导出的结果, 然后规范
 化 / 抽取 / 入图。
 
-下面是 `0.1.0` 时点的**逐源诚实状态**。✅ = 纯 OSS 路径端到端工作;
+下面是 `0.1.1` 时点的**逐源诚实状态**。✅ = 纯 OSS 路径端到端工作;
 ⚠ = 工作但需要第三方导出工具或手动移文件; ❌ = 今天没有推荐的 OSS
 路径, 必须等列出的里程碑。
 
-| 源             | 可用平台              | 今天 (v0.1.0)                                                                                          | 何时更好                                |
+| 源             | 可用平台              | 今天 (v0.1.1)                                                                                          | 何时更好                                |
 |----------------|----------------------|--------------------------------------------------------------------------------------------------------|------------------------------------------|
-| **邮件**       | Win / macOS / Linux  | ✅ `memexa init email` wizard (v0.1.1) — 6 provider 自动识别 (gmail/outlook/icloud/qq/163/foxmail/ustc), 10 min 全程 | —                                        |
+| **邮件**       | Win / macOS / Linux  | ✅ `memexa init email` wizard — 12+ provider 自动识别 (gmail / googlemail / outlook / hotmail / live / icloud / qq / foxmail / 163 / 126 / yeah / sina / mail.ustc); v0.1.1 LIVE-验证过 QQ + USTC IMAP, 其他 provider 走同一代码路径 | —                                        |
 | **音频**       | Win / macOS / Linux  | ✅ 录音笔导出 → Whisper / SenseVoice → JSON → builder                                                  | v0.4 (跨设备 merge, ECAPA 声纹注册)      |
 | **浏览**       | Win / macOS / Linux  | ✅ 读 Chrome / Firefox SQLite history → builder                                                         | —                                        |
 | **Claude Code**| Win / macOS / Linux  | ✅ 读 `~/.claude/projects/*/conversations.jsonl` → builder                                              | —                                        |
-| **微信**       | **仅 Windows**       | ✅ `memexa init wechat` wizard (v0.1.1) wrap [WeChatMsg](https://github.com/LC044/WeChatMsg) — 检测已装 / 没装就指 release 页; 在 WeChatMsg 内导出后 `memexa ingest wechat`。macOS / Linux 用户仍无路径 (上游工具仅 Win)。 | v0.2+ (auto-download + GUI hand-off) |
+| **微信**       | **仅 Windows**       | ✅ `memexa init wechat` wizard wrap [WeChatMsg](https://github.com/LC044/WeChatMsg) — 检测已装 / 没装就指 release 页; 在 WeChatMsg 内导出后 `memexa ingest wechat`。v0.1.1 处理 **6 种消息类型** (文本 / 图片 / 表情 / 视频 / 含标题的 appmsg / 系统消息), 非文本内容不再被静默丢弃。macOS / Linux 用户仍无路径 (上游工具仅 Win)。 | v0.2+ (auto-download + GUI hand-off) |
 | **QQ**         | Win / macOS / Linux  | ⚠ **db-only adapter 还没进 OSS**。NapCat / OneBot 路径**默认关** (腾讯对所有用过 NapCat 的账号指纹封号 — 见 [`integrations/qq.zh.md`](integrations/qq.zh.md))。今天想用 db-only 路径, 手工把上游 JARVIS 的 `jarvis/qq_db.py` 单文件 (762 行, 仅标准库) 拷到 `memexa/extraction/qq/`。剪贴板 fallback 也在上游, 没移植。 | v0.2 (db-only + 剪贴板 fallback 移植; NapCat 路径删除) |
 
 ### 推荐的接入顺序
@@ -309,7 +309,7 @@ Tier 0 / 1 / 2 验证的是**管线**: package 装上、backend 起来、合成
 5. **QQ** — 只在你愿意手工把上游 `qq_db.py` 拷过来时做; 否则等
    v0.2。
 
-### v0.1.0 已知 limitation
+### v0.1.1 已知 limitation
 
 - **QQ db-only adapter** 还没进 OSS 包; 参考实现在上游 JARVIS,
   单文件 762 行, 仅依赖标准库。v0.2 移植。
@@ -317,6 +317,17 @@ Tier 0 / 1 / 2 验证的是**管线**: package 装上、backend 起来、合成
   wechatDataBackup / PyWxDump) 都只在 Windows 上有。macOS /
   Linux 用户**有部署 guide 但没有微信历史路径**。v0.3 跟踪
   (微信 PC 备份 ingestion), 但最终受上游工具生态约束。
+- **其他 IMAP provider** (Gmail / Outlook / iCloud / 163 / 126 /
+  Yeah / Hotmail / Sina / Live) — wizard 对每个都有正确的 host
+  / port / 鉴权提示, 但 v0.1.1 验证只 LIVE-fetched 过 QQ 和
+  USTC。v0.1.2 补齐 LIVE 验证。
+- **Hindsight 异步 consolidation 透明化** — `memexa ingest` 在
+  POST-then-GET verify 看到 `total=0` 时会报 `dead-letter: N`,
+  但卡片通常已经入 document store, 只是后台 consolidator 还
+  没跑。v0.1.2 在 ingest 后自动触发 `/consolidate`。
+- **WeChatMsg 字段名覆盖** — schema adapter 是基于公开字段反向
+  工程的; 未来 WeChatMsg release 若 emit 全新字段可能需要
+  v0.1.2 补丁。
 - **没有 飞书 / 钉钉 adapter** — v0.3。
 - **没有本地文档源** (`.md` / `.pdf` / `.docx` / `.txt`) — v0.3。
 - **没有 `--embedded` backend 模式** — Tier 1 / Tier 2 仍需


### PR DESCRIPTION
Post-v0.1.1 documentation hygiene.

## ROADMAP.md / ROADMAP.zh.md

Split the v0.1.x section into three sub-sections:

- **v0.1.0** (shipped 2026-05-17) — short retrospective.
- **v0.1.1** (shipped 2026-05-17) — what landed + LIVE attestation summary.
- **v0.1.2** (in progress) — formalized as four LIVE-gap items:
  1. **Other IMAP providers** (Gmail / Outlook / iCloud / 163 / 126 / Yeah / Hotmail / Sina / Live) — LIVE-fetch attestation per provider, integration matrix update.
  2. **Hindsight async-consolidation transparency** — auto-trigger `/consolidate` after ingest, or print "indexing in background, queryable in ≤60s".
  3. **Large-volume ingest (>500 batches)** — stress test rate-limit back-pressure, dead-letter recovery, memory footprint; document empirical knobs.
  4. **WeChatMsg-from-the-real-binary** — drive at least one real WeChatMsg release export through the pipeline + patch field-name surprises.

Optional community-health items (non-maintainer issue / 1-week clean main) queued behind the four above.

## docs/quickstart.md / docs/quickstart.zh.md

Tier 3 status table + known-limitations bumped from "0.1.0" → "0.1.1":

- Email row: 6 → 12+ providers (gmail / googlemail / outlook / hotmail / live / icloud / qq / foxmail / 163 / 126 / yeah / sina / mail.ustc) with v0.1.1 LIVE-attested on QQ + USTC.
- WeChat row: notes the 6 msg-type adapter coverage (text / image / sticker / video / appmsg-with-title / system-msg).
- Known-limitations section refreshed with the four v0.1.2 gap items.

EN ↔ ZH kept in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)